### PR TITLE
Replace2D

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Carthage/Checkouts/ReactiveKit"]
 	path = Carthage/Checkouts/ReactiveKit
 	url = https://github.com/ReactiveKit/ReactiveKit.git
+[submodule "Carthage/Checkouts/Diff.swift"]
+	path = Carthage/Checkouts/Diff.swift
+	url = https://github.com/wokalski/Diff.swift.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ install:
   - gem install xcpretty
 
 script:
-  - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme Bond-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.1' test | xcpretty
+  - set -o pipefail
+  - travis_retry xcodebuild -project Bond.xcodeproj -scheme Bond-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.2' test | xcpretty
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - gem install xcpretty
 
 script:
-  - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme Bond-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.2' test | xcpretty
+  - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme Bond-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.1' test | xcpretty
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ osx_image: xcode8.2
 # Travis is currently experiencing issues with Xcode builds: https://github.com/travis-ci/travis-ci/issues/6675#issuecomment-257964767
 # When this is resolved, remove the entire `before_install` block, as well as the `travis_retry` command below.
 before_install:
-  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone 6s (10.2" | awk -F '[ ]' '{print $4}' | awk -F '[\[]' '{print $2}' | sed 's/.$//'`
+  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone 7 (10.1" | awk -F '[ ]' '{print $4}' | awk -F '[\[]' '{print $2}' | sed 's/.$//'`
   - echo $IOS_SIMULATOR_UDID
   - open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
 
@@ -12,7 +12,7 @@ install:
   - gem install xcpretty
 
 script:
-  - set -o pipefail && travis_retry xcodebuild -project Bond.xcodeproj -scheme Bond-iOS -sdk iphonesimulator10.2 -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.2' test | xcpretty
+  - set -o pipefail && travis_retry xcodebuild -project Bond.xcodeproj -scheme Bond-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.1' test | xcpretty
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: objective-c
 osx_image: xcode8.2
 
+# Travis is currently experiencing issues with Xcode builds: https://github.com/travis-ci/travis-ci/issues/6675#issuecomment-257964767
+# When this is resolved, remove the entire `before_install` block, as well as the `travis_retry` command below.
+before_install:
+  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone 6s (10.2" | awk -F '[ ]' '{print $4}' | awk -F '[\[]' '{print $2}' | sed 's/.$//'`
+  - echo $IOS_SIMULATOR_UDID
+  - open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
+
 install:
   - gem install xcpretty
 
 script:
-  - set -o pipefail
-  - travis_retry xcodebuild -project Bond.xcodeproj -scheme Bond-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.2' test | xcpretty
+  - set -o pipefail && travis_retry xcodebuild -project Bond.xcodeproj -scheme Bond-iOS -sdk iphonesimulator10.2 -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.2' test | xcpretty
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ install:
 
 script:
   - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme Bond-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.2' test | xcpretty
-#  - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme BondOSX -sdk macosx test | xcpretty
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: objective-c
-osx_image: xcode8
+osx_image: xcode8.2
 
 install:
   - gem install xcpretty
 
 script:
-  - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme Bond-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.0' test | xcpretty
+  - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme Bond-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6s,OS=10.2' test | xcpretty
 #  - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme BondOSX -sdk macosx test | xcpretty
 
 after_success:

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.osx.exclude_files = "Sources/UIKit"
   s.requires_arc = true
 
-  s.dependency 'ReactiveKit', '~> 3.1'
+  s.dependency 'ReactiveKit', '~> 3.1.2'
   s.dependency 'Diff.swift', '~> 0.4'
 
 end

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bond"
-  s.version      = "5.1.0"
+  s.version      = "5.1.1"
   s.summary      = "A Swift binding framework"
 
   s.description  = <<-DESC
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = '9.0'
-  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "v5.1.0" }
+  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "v5.1.1" }
   s.source_files  = 'Sources/**/*.swift', 'Bond/*.{h,m,swift}'
   s.ios.exclude_files = "Sources/AppKit"
   s.tvos.exclude_files = "Sources/AppKit"

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -29,4 +29,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'ReactiveKit', '~> 3.1'
+  s.dependency 'Diff.swift', '~> 0.4'
+
 end

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bond"
-  s.version      = "6.0.0-beta.2"
+  s.version      = "6.0.0-beta.3"
   s.summary      = "A Swift binding framework"
 
   s.description  = <<-DESC
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = '9.0'
-  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "6.0.0-beta.2" }
+  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "6.0.0-beta.3" }
   s.source_files  = 'Sources/**/*.swift', 'Bond/*.{h,m,swift}'
   s.ios.exclude_files = "Sources/AppKit"
   s.tvos.exclude_files = "Sources/AppKit"

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bond"
-  s.version      = "6.0.0-alpha.1"
+  s.version      = "6.0.0"
   s.summary      = "A Swift binding framework"
 
   s.description  = <<-DESC
@@ -21,14 +21,14 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = '9.0'
-  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "6.0.0-alpha.1" }
+  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "6.0.0" }
   s.source_files  = 'Sources/**/*.swift', 'Bond/*.{h,m,swift}'
   s.ios.exclude_files = "Sources/AppKit"
   s.tvos.exclude_files = "Sources/AppKit"
   s.osx.exclude_files = "Sources/UIKit"
   s.requires_arc = true
 
-  s.dependency 'ReactiveKit', '~> 3.1.2'
+  s.dependency 'ReactiveKit', '~> 3.2'
   s.dependency 'Diff', '~> 0.4'
 
 end

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bond"
-  s.version      = "5.1.1"
+  s.version      = "6.0.0-alpha.1"
   s.summary      = "A Swift binding framework"
 
   s.description  = <<-DESC
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = '9.0'
-  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "v5.1.1" }
+  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "6.0.0-alpha.1" }
   s.source_files  = 'Sources/**/*.swift', 'Bond/*.{h,m,swift}'
   s.ios.exclude_files = "Sources/AppKit"
   s.tvos.exclude_files = "Sources/AppKit"

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bond"
-  s.version      = "6.0.0"
+  s.version      = "6.0.0-beta1"
   s.summary      = "A Swift binding framework"
 
   s.description  = <<-DESC
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = '9.0'
-  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "6.0.0" }
+  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "6.0.0-beta1" }
   s.source_files  = 'Sources/**/*.swift', 'Bond/*.{h,m,swift}'
   s.ios.exclude_files = "Sources/AppKit"
   s.tvos.exclude_files = "Sources/AppKit"

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bond"
-  s.version      = "6.0.0-beta.1"
+  s.version      = "6.0.0-beta.2"
   s.summary      = "A Swift binding framework"
 
   s.description  = <<-DESC
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = '9.0'
-  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "6.0.0-beta.1" }
+  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "6.0.0-beta.2" }
   s.source_files  = 'Sources/**/*.swift', 'Bond/*.{h,m,swift}'
   s.ios.exclude_files = "Sources/AppKit"
   s.tvos.exclude_files = "Sources/AppKit"

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'ReactiveKit', '~> 3.1.2'
-  s.dependency 'Diff.swift', '~> 0.4'
+  s.dependency 'Diff', '~> 0.4'
 
 end

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bond"
-  s.version      = "6.0.0-beta1"
+  s.version      = "6.0.0-beta.1"
   s.summary      = "A Swift binding framework"
 
   s.description  = <<-DESC
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = '9.0'
-  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "6.0.0-beta1" }
+  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "6.0.0-beta.1" }
   s.source_files  = 'Sources/**/*.swift', 'Bond/*.{h,m,swift}'
   s.ios.exclude_files = "Sources/AppKit"
   s.tvos.exclude_files = "Sources/AppKit"

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'ReactiveKit', '~> 3.1.2'
-  s.dependency 'Diff.swift', '~> 0.4'
+  s.dependency 'Diff.swift', '~> 0.4.1'
 
 end

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bond"
-  s.version      = "5.3.1"
+  s.version      = "5.4.0"
   s.summary      = "A Swift binding framework"
 
   s.description  = <<-DESC
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = '9.0'
-  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "v5.3.1" }
+  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "v5.4.0" }
   s.source_files  = 'Sources/**/*.swift', 'Bond/*.{h,m,swift}'
   s.ios.exclude_files = "Sources/AppKit"
   s.tvos.exclude_files = "Sources/AppKit"

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'ReactiveKit', '~> 3.1.2'
-  s.dependency 'Diff.swift', '~> 0.4.1'
+  s.dependency 'Diff.swift', '~> 0.4'
 
 end

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		16D30F091D65D82D00C2435D /* NSAppearanceCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F081D65D82C00C2435D /* NSAppearanceCustomization.swift */; };
 		16D30F0B1D65E8C700C2435D /* NSTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F0A1D65E8C700C2435D /* NSTableView.swift */; };
 		227DEF051DCB87BF00213852 /* UIGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227DEF041DCB87BF00213852 /* UIGestureRecognizer.swift */; };
+		90449ECA1E26F7DC00EE00DD /* NSPopUpButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90449EC41E26F78C00EE00DD /* NSPopUpButton.swift */; };
 		90A3FACD1E0C8D9A0086A7F1 /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
 		90A3FACE1E0C8D9F0086A7F1 /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
 		90A3FACF1E0C8DA20086A7F1 /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
@@ -276,6 +277,7 @@
 		16D30F081D65D82C00C2435D /* NSAppearanceCustomization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAppearanceCustomization.swift; sourceTree = "<group>"; };
 		16D30F0A1D65E8C700C2435D /* NSTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTableView.swift; sourceTree = "<group>"; };
 		227DEF041DCB87BF00213852 /* UIGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIGestureRecognizer.swift; sourceTree = "<group>"; };
+		90449EC41E26F78C00EE00DD /* NSPopUpButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSPopUpButton.swift; sourceTree = "<group>"; };
 		90A3FAC21E0C8D8B0086A7F1 /* Diff.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Diff.xcodeproj; path = Carthage/Checkouts/Diff.swift/Diff.xcodeproj; sourceTree = "<group>"; };
 		EC06A8751DBCB147006AEA81 /* NSObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObjectTests.swift; sourceTree = "<group>"; };
 		EC2505B01D3F570500A6E14A /* UILabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UILabel.swift; path = Sources/UIKit/UILabel.swift; sourceTree = SOURCE_ROOT; };
@@ -473,6 +475,7 @@
 				16D30EC31D65988A00C2435D /* NSControl.swift */,
 				16D30EC51D659B8F00C2435D /* NSImageView.swift */,
 				16D30F041D65D7C000C2435D /* NSMenuItem.swift */,
+				90449EC41E26F78C00EE00DD /* NSPopUpButton.swift */,
 				16D30EC71D659BDB00C2435D /* NSProgressIndicator.swift */,
 				16D30EC91D659C1200C2435D /* NSSegmentedControl.swift */,
 				16D30ECB1D659CA700C2435D /* NSSlider.swift */,
@@ -956,6 +959,7 @@
 				EC877A9F1E01CE1200A23B51 /* NSObject.swift in Sources */,
 				16D30EC81D659BDB00C2435D /* NSProgressIndicator.swift in Sources */,
 				EC877A9C1E01CE1200A23B51 /* NSObject+KVO.swift in Sources */,
+				90449ECA1E26F7DC00EE00DD /* NSPopUpButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -467,20 +467,20 @@
 		16D30EBA1D65944500C2435D /* AppKit */ = {
 			isa = PBXGroup;
 			children = (
+				16D30F081D65D82C00C2435D /* NSAppearanceCustomization.swift */,
 				16D30EBB1D65944500C2435D /* NSButton.swift */,
+				16D30F061D65D7F800C2435D /* NSColorWell.swift */,
 				16D30EC31D65988A00C2435D /* NSControl.swift */,
 				16D30EC51D659B8F00C2435D /* NSImageView.swift */,
+				16D30F041D65D7C000C2435D /* NSMenuItem.swift */,
 				16D30EC71D659BDB00C2435D /* NSProgressIndicator.swift */,
 				16D30EC91D659C1200C2435D /* NSSegmentedControl.swift */,
 				16D30ECB1D659CA700C2435D /* NSSlider.swift */,
-				16D30ECD1D659D4A00C2435D /* NSTextField.swift */,
-				16D30ECF1D659E0600C2435D /* NSView.swift */,
-				16D30F001D65D6AA00C2435D /* NSTextView.swift */,
 				16D30F021D65D79600C2435D /* NSStatusBarButton.swift */,
-				16D30F041D65D7C000C2435D /* NSMenuItem.swift */,
-				16D30F061D65D7F800C2435D /* NSColorWell.swift */,
-				16D30F081D65D82C00C2435D /* NSAppearanceCustomization.swift */,
 				16D30F0A1D65E8C700C2435D /* NSTableView.swift */,
+				16D30ECD1D659D4A00C2435D /* NSTextField.swift */,
+				16D30F001D65D6AA00C2435D /* NSTextView.swift */,
+				16D30ECF1D659E0600C2435D /* NSView.swift */,
 			);
 			path = AppKit;
 			sourceTree = "<group>";

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -9,15 +9,6 @@
 /* Begin PBXBuildFile section */
 		16210A461D3EC474004AEDF3 /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16210A3C1D3EC474004AEDF3 /* Bond.framework */; };
 		16210A4B1D3EC474004AEDF3 /* UIKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16210A4A1D3EC474004AEDF3 /* UIKitTests.swift */; };
-		1639C0801D6DD3190045959E /* ObservableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639C07D1D6DD3190045959E /* ObservableArray.swift */; };
-		1639C0811D6DD3190045959E /* ObservableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639C07D1D6DD3190045959E /* ObservableArray.swift */; };
-		1639C0821D6DD3190045959E /* ObservableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639C07D1D6DD3190045959E /* ObservableArray.swift */; };
-		1639C0831D6DD3190045959E /* ObservableDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639C07E1D6DD3190045959E /* ObservableDictionary.swift */; };
-		1639C0841D6DD3190045959E /* ObservableDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639C07E1D6DD3190045959E /* ObservableDictionary.swift */; };
-		1639C0851D6DD3190045959E /* ObservableDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639C07E1D6DD3190045959E /* ObservableDictionary.swift */; };
-		1639C0861D6DD3190045959E /* ObservableSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639C07F1D6DD3190045959E /* ObservableSet.swift */; };
-		1639C0871D6DD3190045959E /* ObservableSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639C07F1D6DD3190045959E /* ObservableSet.swift */; };
-		1639C0881D6DD3190045959E /* ObservableSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639C07F1D6DD3190045959E /* ObservableSet.swift */; };
 		1639C08A1D6DD39B0045959E /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639C0891D6DD39B0045959E /* Observable.swift */; };
 		1639C08B1D6DD39B0045959E /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639C0891D6DD39B0045959E /* Observable.swift */; };
 		1639C08C1D6DD39B0045959E /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1639C0891D6DD39B0045959E /* Observable.swift */; };
@@ -37,7 +28,6 @@
 		16D30EBF1D65960B00C2435D /* Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7890F11D44F1D9002848EB /* Bond.swift */; };
 		16D30EC01D65960E00C2435D /* DynamicSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7890F31D44F1ED002848EB /* DynamicSubject.swift */; };
 		16D30EC11D65961000C2435D /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16559F841D64F4F100EDD727 /* DataSource.swift */; };
-		16D30EC21D65961300C2435D /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8822061D421EA2006142ED /* NSObject.swift */; };
 		16D30EC41D65988A00C2435D /* NSControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30EC31D65988A00C2435D /* NSControl.swift */; };
 		16D30EC61D659B8F00C2435D /* NSImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30EC51D659B8F00C2435D /* NSImageView.swift */; };
 		16D30EC81D659BDB00C2435D /* NSProgressIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30EC71D659BDB00C2435D /* NSProgressIndicator.swift */; };
@@ -49,7 +39,6 @@
 		16D30EDF1D65D14C00C2435D /* Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7890F11D44F1D9002848EB /* Bond.swift */; };
 		16D30EE01D65D14C00C2435D /* DynamicSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7890F31D44F1ED002848EB /* DynamicSubject.swift */; };
 		16D30EE11D65D14C00C2435D /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16559F841D64F4F100EDD727 /* DataSource.swift */; };
-		16D30EE21D65D14C00C2435D /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8822061D421EA2006142ED /* NSObject.swift */; };
 		16D30EE31D65D16600C2435D /* UIActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD626E81D4DE8800040C7BF /* UIActivityIndicatorView.swift */; };
 		16D30EE41D65D16600C2435D /* UIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD626EE1D4DEAB20040C7BF /* UIApplication.swift */; };
 		16D30EE51D65D16600C2435D /* UIBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD626EC1D4DE9BE0040C7BF /* UIBarButtonItem.swift */; };
@@ -71,12 +60,6 @@
 		16D30EF51D65D16600C2435D /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD627041D4DF67E0040C7BF /* UIView.swift */; };
 		16D30EF61D65D16600C2435D /* UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16559F821D64F4BC00EDD727 /* UITableView.swift */; };
 		16D30EF71D65D16600C2435D /* UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30EA71D6587B400C2435D /* UICollectionView.swift */; };
-		16D30EF91D65D5FD00C2435D /* CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30EF81D65D5FD00C2435D /* CALayer.swift */; };
-		16D30EFA1D65D5FD00C2435D /* CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30EF81D65D5FD00C2435D /* CALayer.swift */; };
-		16D30EFB1D65D5FD00C2435D /* CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30EF81D65D5FD00C2435D /* CALayer.swift */; };
-		16D30EFD1D65D64600C2435D /* NSLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30EFC1D65D64600C2435D /* NSLayoutConstraint.swift */; };
-		16D30EFE1D65D64600C2435D /* NSLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30EFC1D65D64600C2435D /* NSLayoutConstraint.swift */; };
-		16D30EFF1D65D64600C2435D /* NSLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30EFC1D65D64600C2435D /* NSLayoutConstraint.swift */; };
 		16D30F011D65D6AA00C2435D /* NSTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F001D65D6AA00C2435D /* NSTextView.swift */; };
 		16D30F031D65D79600C2435D /* NSStatusBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F021D65D79600C2435D /* NSStatusBarButton.swift */; };
 		16D30F051D65D7C000C2435D /* NSMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F041D65D7C000C2435D /* NSMenuItem.swift */; };
@@ -97,24 +80,43 @@
 		EC7890EF1D44F1BF002848EB /* Bond.h in Headers */ = {isa = PBXBuildFile; fileRef = EC7890ED1D44F1BF002848EB /* Bond.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EC7890F21D44F1D9002848EB /* Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7890F11D44F1D9002848EB /* Bond.swift */; };
 		EC7890F41D44F1ED002848EB /* DynamicSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7890F31D44F1ED002848EB /* DynamicSubject.swift */; };
-		EC877A851E0194E700A23B51 /* SignalProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A841E0194E700A23B51 /* SignalProtocol.swift */; };
-		EC8822071D421EA2006142ED /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8822061D421EA2006142ED /* NSObject.swift */; };
+		EC877A921E01CE1200A23B51 /* CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A8C1E01CE1200A23B51 /* CALayer.swift */; };
+		EC877A931E01CE1200A23B51 /* CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A8C1E01CE1200A23B51 /* CALayer.swift */; };
+		EC877A941E01CE1200A23B51 /* CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A8C1E01CE1200A23B51 /* CALayer.swift */; };
+		EC877A951E01CE1200A23B51 /* NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A8D1E01CE1200A23B51 /* NotificationCenter.swift */; };
+		EC877A961E01CE1200A23B51 /* NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A8D1E01CE1200A23B51 /* NotificationCenter.swift */; };
+		EC877A971E01CE1200A23B51 /* NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A8D1E01CE1200A23B51 /* NotificationCenter.swift */; };
+		EC877A981E01CE1200A23B51 /* NSLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A8E1E01CE1200A23B51 /* NSLayoutConstraint.swift */; };
+		EC877A991E01CE1200A23B51 /* NSLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A8E1E01CE1200A23B51 /* NSLayoutConstraint.swift */; };
+		EC877A9A1E01CE1200A23B51 /* NSLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A8E1E01CE1200A23B51 /* NSLayoutConstraint.swift */; };
+		EC877A9B1E01CE1200A23B51 /* NSObject+KVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A8F1E01CE1200A23B51 /* NSObject+KVO.swift */; };
+		EC877A9C1E01CE1200A23B51 /* NSObject+KVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A8F1E01CE1200A23B51 /* NSObject+KVO.swift */; };
+		EC877A9D1E01CE1200A23B51 /* NSObject+KVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A8F1E01CE1200A23B51 /* NSObject+KVO.swift */; };
+		EC877A9E1E01CE1200A23B51 /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A901E01CE1200A23B51 /* NSObject.swift */; };
+		EC877A9F1E01CE1200A23B51 /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A901E01CE1200A23B51 /* NSObject.swift */; };
+		EC877AA01E01CE1200A23B51 /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A901E01CE1200A23B51 /* NSObject.swift */; };
+		EC877AA11E01CE1200A23B51 /* SignalProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A911E01CE1200A23B51 /* SignalProtocol.swift */; };
+		EC877AA21E01CE1200A23B51 /* SignalProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A911E01CE1200A23B51 /* SignalProtocol.swift */; };
+		EC877AA31E01CE1200A23B51 /* SignalProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A911E01CE1200A23B51 /* SignalProtocol.swift */; };
+		EC877AA61E01CE6100A23B51 /* ProtocolProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AA51E01CE6100A23B51 /* ProtocolProxy.swift */; };
+		EC877AA71E01CE6100A23B51 /* ProtocolProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AA51E01CE6100A23B51 /* ProtocolProxy.swift */; };
+		EC877AA81E01CE6100A23B51 /* ProtocolProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AA51E01CE6100A23B51 /* ProtocolProxy.swift */; };
+		EC877AAF1E01CE9F00A23B51 /* Observable2DArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AAB1E01CE9F00A23B51 /* Observable2DArray.swift */; };
+		EC877AB01E01CE9F00A23B51 /* Observable2DArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AAB1E01CE9F00A23B51 /* Observable2DArray.swift */; };
+		EC877AB11E01CE9F00A23B51 /* Observable2DArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AAB1E01CE9F00A23B51 /* Observable2DArray.swift */; };
+		EC877AB21E01CE9F00A23B51 /* ObservableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AAC1E01CE9F00A23B51 /* ObservableArray.swift */; };
+		EC877AB31E01CE9F00A23B51 /* ObservableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AAC1E01CE9F00A23B51 /* ObservableArray.swift */; };
+		EC877AB41E01CE9F00A23B51 /* ObservableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AAC1E01CE9F00A23B51 /* ObservableArray.swift */; };
+		EC877AB51E01CE9F00A23B51 /* ObservableDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AAD1E01CE9F00A23B51 /* ObservableDictionary.swift */; };
+		EC877AB61E01CE9F00A23B51 /* ObservableDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AAD1E01CE9F00A23B51 /* ObservableDictionary.swift */; };
+		EC877AB71E01CE9F00A23B51 /* ObservableDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AAD1E01CE9F00A23B51 /* ObservableDictionary.swift */; };
+		EC877AB81E01CE9F00A23B51 /* ObservableSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AAE1E01CE9F00A23B51 /* ObservableSet.swift */; };
+		EC877AB91E01CE9F00A23B51 /* ObservableSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AAE1E01CE9F00A23B51 /* ObservableSet.swift */; };
+		EC877ABA1E01CE9F00A23B51 /* ObservableSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877AAE1E01CE9F00A23B51 /* ObservableSet.swift */; };
 		EC96935B1D943B15004EB5EE /* UITableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC96935A1D943B15004EB5EE /* UITableViewTests.swift */; };
 		EC96935F1D945CC6004EB5EE /* UICollectionViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC96935E1D945CC6004EB5EE /* UICollectionViewTests.swift */; };
-		EC9693611D94613A004EB5EE /* Observable2DArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9693601D94613A004EB5EE /* Observable2DArray.swift */; };
-		EC9693621D94613A004EB5EE /* Observable2DArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9693601D94613A004EB5EE /* Observable2DArray.swift */; };
-		EC9693631D94613A004EB5EE /* Observable2DArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC9693601D94613A004EB5EE /* Observable2DArray.swift */; };
 		EC9693661D947243004EB5EE /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16210A3C1D3EC474004AEDF3 /* Bond.framework */; };
 		EC9693671D94724C004EB5EE /* ReactiveKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1652178B1D70591E00C9FAEE /* ReactiveKit.framework */; };
-		EC97ED9F1D6C500B001C54C9 /* NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC97ED9E1D6C500B001C54C9 /* NotificationCenter.swift */; };
-		EC97EDA01D6C500B001C54C9 /* NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC97ED9E1D6C500B001C54C9 /* NotificationCenter.swift */; };
-		EC97EDA11D6C500B001C54C9 /* NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC97ED9E1D6C500B001C54C9 /* NotificationCenter.swift */; };
-		EC97EDA31D6C50A5001C54C9 /* NSObject+KVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC97EDA21D6C50A5001C54C9 /* NSObject+KVO.swift */; };
-		EC97EDA41D6C50A5001C54C9 /* NSObject+KVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC97EDA21D6C50A5001C54C9 /* NSObject+KVO.swift */; };
-		EC97EDA51D6C50A5001C54C9 /* NSObject+KVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC97EDA21D6C50A5001C54C9 /* NSObject+KVO.swift */; };
-		EC97EDA91D6C51F0001C54C9 /* ProtocolProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC97EDA61D6C51F0001C54C9 /* ProtocolProxy.swift */; };
-		EC97EDAA1D6C51F0001C54C9 /* ProtocolProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC97EDA61D6C51F0001C54C9 /* ProtocolProxy.swift */; };
-		EC97EDAB1D6C51F0001C54C9 /* ProtocolProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC97EDA61D6C51F0001C54C9 /* ProtocolProxy.swift */; };
 		EC97EDAC1D6C51F0001C54C9 /* BNDProtocolProxyBase.h in Headers */ = {isa = PBXBuildFile; fileRef = EC97EDA71D6C51F0001C54C9 /* BNDProtocolProxyBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EC97EDAD1D6C51F0001C54C9 /* BNDProtocolProxyBase.h in Headers */ = {isa = PBXBuildFile; fileRef = EC97EDA71D6C51F0001C54C9 /* BNDProtocolProxyBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EC97EDAE1D6C51F0001C54C9 /* BNDProtocolProxyBase.h in Headers */ = {isa = PBXBuildFile; fileRef = EC97EDA71D6C51F0001C54C9 /* BNDProtocolProxyBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -229,9 +231,6 @@
 		16210A451D3EC474004AEDF3 /* BondTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BondTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		16210A4A1D3EC474004AEDF3 /* UIKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitTests.swift; sourceTree = "<group>"; };
 		16210A4C1D3EC474004AEDF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		1639C07D1D6DD3190045959E /* ObservableArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservableArray.swift; sourceTree = "<group>"; };
-		1639C07E1D6DD3190045959E /* ObservableDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservableDictionary.swift; sourceTree = "<group>"; };
-		1639C07F1D6DD3190045959E /* ObservableSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservableSet.swift; sourceTree = "<group>"; };
 		1639C0891D6DD39B0045959E /* Observable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		165217821D70591D00C9FAEE /* ReactiveKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ReactiveKit.xcodeproj; path = Carthage/Checkouts/ReactiveKit/ReactiveKit.xcodeproj; sourceTree = "<group>"; };
 		16559F821D64F4BC00EDD727 /* UITableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITableView.swift; sourceTree = "<group>"; };
@@ -253,8 +252,6 @@
 		16D30ECD1D659D4A00C2435D /* NSTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTextField.swift; sourceTree = "<group>"; };
 		16D30ECF1D659E0600C2435D /* NSView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSView.swift; sourceTree = "<group>"; };
 		16D30ED61D65D11900C2435D /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		16D30EF81D65D5FD00C2435D /* CALayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CALayer.swift; sourceTree = "<group>"; };
-		16D30EFC1D65D64600C2435D /* NSLayoutConstraint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraint.swift; sourceTree = "<group>"; };
 		16D30F001D65D6AA00C2435D /* NSTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTextView.swift; sourceTree = "<group>"; };
 		16D30F021D65D79600C2435D /* NSStatusBarButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSStatusBarButton.swift; sourceTree = "<group>"; };
 		16D30F041D65D7C000C2435D /* NSMenuItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMenuItem.swift; sourceTree = "<group>"; };
@@ -272,14 +269,19 @@
 		EC7890EE1D44F1BF002848EB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Bond/Info.plist; sourceTree = "<group>"; };
 		EC7890F11D44F1D9002848EB /* Bond.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bond.swift; sourceTree = "<group>"; };
 		EC7890F31D44F1ED002848EB /* DynamicSubject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicSubject.swift; sourceTree = "<group>"; };
-		EC877A841E0194E700A23B51 /* SignalProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalProtocol.swift; sourceTree = "<group>"; };
-		EC8822061D421EA2006142ED /* NSObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSObject.swift; path = Sources/NSObject.swift; sourceTree = SOURCE_ROOT; };
+		EC877A8C1E01CE1200A23B51 /* CALayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CALayer.swift; sourceTree = "<group>"; };
+		EC877A8D1E01CE1200A23B51 /* NotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationCenter.swift; sourceTree = "<group>"; };
+		EC877A8E1E01CE1200A23B51 /* NSLayoutConstraint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraint.swift; sourceTree = "<group>"; };
+		EC877A8F1E01CE1200A23B51 /* NSObject+KVO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+KVO.swift"; sourceTree = "<group>"; };
+		EC877A901E01CE1200A23B51 /* NSObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObject.swift; sourceTree = "<group>"; };
+		EC877A911E01CE1200A23B51 /* SignalProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalProtocol.swift; sourceTree = "<group>"; };
+		EC877AA51E01CE6100A23B51 /* ProtocolProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProtocolProxy.swift; sourceTree = "<group>"; };
+		EC877AAB1E01CE9F00A23B51 /* Observable2DArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable2DArray.swift; sourceTree = "<group>"; };
+		EC877AAC1E01CE9F00A23B51 /* ObservableArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservableArray.swift; sourceTree = "<group>"; };
+		EC877AAD1E01CE9F00A23B51 /* ObservableDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservableDictionary.swift; sourceTree = "<group>"; };
+		EC877AAE1E01CE9F00A23B51 /* ObservableSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservableSet.swift; sourceTree = "<group>"; };
 		EC96935A1D943B15004EB5EE /* UITableViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITableViewTests.swift; sourceTree = "<group>"; };
 		EC96935E1D945CC6004EB5EE /* UICollectionViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICollectionViewTests.swift; sourceTree = "<group>"; };
-		EC9693601D94613A004EB5EE /* Observable2DArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable2DArray.swift; sourceTree = "<group>"; };
-		EC97ED9E1D6C500B001C54C9 /* NotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationCenter.swift; sourceTree = "<group>"; };
-		EC97EDA21D6C50A5001C54C9 /* NSObject+KVO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+KVO.swift"; sourceTree = "<group>"; };
-		EC97EDA61D6C51F0001C54C9 /* ProtocolProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ProtocolProxy.swift; path = Bond/ProtocolProxy.swift; sourceTree = SOURCE_ROOT; };
 		EC97EDA71D6C51F0001C54C9 /* BNDProtocolProxyBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BNDProtocolProxyBase.h; path = Bond/BNDProtocolProxyBase.h; sourceTree = SOURCE_ROOT; };
 		EC97EDA81D6C51F0001C54C9 /* BNDProtocolProxyBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BNDProtocolProxyBase.m; path = Bond/BNDProtocolProxyBase.m; sourceTree = SOURCE_ROOT; };
 		ECC4BE581D4A2E1600880DEC /* UIButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButton.swift; sourceTree = "<group>"; };
@@ -386,24 +388,13 @@
 			isa = PBXGroup;
 			children = (
 				1639C0891D6DD39B0045959E /* Observable.swift */,
-				1639C07D1D6DD3190045959E /* ObservableArray.swift */,
-				EC9693601D94613A004EB5EE /* Observable2DArray.swift */,
-				1639C07E1D6DD3190045959E /* ObservableDictionary.swift */,
-				1639C07F1D6DD3190045959E /* ObservableSet.swift */,
 				EC7890F11D44F1D9002848EB /* Bond.swift */,
 				EC7890F31D44F1ED002848EB /* DynamicSubject.swift */,
-				EC97EDA61D6C51F0001C54C9 /* ProtocolProxy.swift */,
+				EC877AA51E01CE6100A23B51 /* ProtocolProxy.swift */,
 				16559F841D64F4F100EDD727 /* DataSource.swift */,
-				EC8822061D421EA2006142ED /* NSObject.swift */,
-				EC97EDA21D6C50A5001C54C9 /* NSObject+KVO.swift */,
-				16D30EF81D65D5FD00C2435D /* CALayer.swift */,
-				16D30EFC1D65D64600C2435D /* NSLayoutConstraint.swift */,
-				EC97ED9E1D6C500B001C54C9 /* NotificationCenter.swift */,
-				EC877A841E0194E700A23B51 /* SignalProtocol.swift */,
-				EC97EDA71D6C51F0001C54C9 /* BNDProtocolProxyBase.h */,
-				EC97EDA81D6C51F0001C54C9 /* BNDProtocolProxyBase.m */,
-				EC2D4A0D1DA8F31700B03A6B /* NSObject+Bond.h */,
-				EC2D4A131DA8F36B00B03A6B /* NSObject+Bond.m */,
+				EC877AAA1E01CE9F00A23B51 /* Collections */,
+				EC877AA41E01CE4900A23B51 /* ObjC */,
+				EC877A8B1E01CE1200A23B51 /* Shared */,
 				16D30EBA1D65944500C2435D /* AppKit */,
 				EC2505AF1D3F56D900A6E14A /* UIKit */,
 			);
@@ -499,6 +490,41 @@
 			);
 			name = UIKit;
 			path = ../Sources/UIKit;
+			sourceTree = "<group>";
+		};
+		EC877A8B1E01CE1200A23B51 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				EC877A8C1E01CE1200A23B51 /* CALayer.swift */,
+				EC877A8D1E01CE1200A23B51 /* NotificationCenter.swift */,
+				EC877A8E1E01CE1200A23B51 /* NSLayoutConstraint.swift */,
+				EC877A901E01CE1200A23B51 /* NSObject.swift */,
+				EC877A8F1E01CE1200A23B51 /* NSObject+KVO.swift */,
+				EC877A911E01CE1200A23B51 /* SignalProtocol.swift */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		EC877AA41E01CE4900A23B51 /* ObjC */ = {
+			isa = PBXGroup;
+			children = (
+				EC97EDA71D6C51F0001C54C9 /* BNDProtocolProxyBase.h */,
+				EC97EDA81D6C51F0001C54C9 /* BNDProtocolProxyBase.m */,
+				EC2D4A0D1DA8F31700B03A6B /* NSObject+Bond.h */,
+				EC2D4A131DA8F36B00B03A6B /* NSObject+Bond.m */,
+			);
+			name = ObjC;
+			sourceTree = "<group>";
+		};
+		EC877AAA1E01CE9F00A23B51 /* Collections */ = {
+			isa = PBXGroup;
+			children = (
+				EC877AAB1E01CE9F00A23B51 /* Observable2DArray.swift */,
+				EC877AAC1E01CE9F00A23B51 /* ObservableArray.swift */,
+				EC877AAD1E01CE9F00A23B51 /* ObservableDictionary.swift */,
+				EC877AAE1E01CE9F00A23B51 /* ObservableSet.swift */,
+			);
+			path = Collections;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -777,46 +803,46 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1639C0831D6DD3190045959E /* ObservableDictionary.swift in Sources */,
+				EC877AAF1E01CE9F00A23B51 /* Observable2DArray.swift in Sources */,
 				16D30EA81D6587B400C2435D /* UICollectionView.swift in Sources */,
+				EC877AA61E01CE6100A23B51 /* ProtocolProxy.swift in Sources */,
 				ECD626F71D4DF1260040C7BF /* UINavigationItem.swift in Sources */,
 				227DEF051DCB87BF00213852 /* UIGestureRecognizer.swift in Sources */,
-				EC97EDA91D6C51F0001C54C9 /* ProtocolProxy.swift in Sources */,
+				EC877A921E01CE1200A23B51 /* CALayer.swift in Sources */,
 				ECD627011D4DF3DD0040C7BF /* UISwitch.swift in Sources */,
+				EC877A951E01CE1200A23B51 /* NotificationCenter.swift in Sources */,
 				ECD627051D4DF67E0040C7BF /* UIView.swift in Sources */,
 				F411F9F01D9CEC5200AEBAFC /* UIStepper.swift in Sources */,
 				ECD626EB1D4DE9460040C7BF /* UIBarItem.swift in Sources */,
-				1639C0861D6DD3190045959E /* ObservableSet.swift in Sources */,
 				EC7890F21D44F1D9002848EB /* Bond.swift in Sources */,
 				EC7890F41D44F1ED002848EB /* DynamicSubject.swift in Sources */,
 				16559F851D64F4F100EDD727 /* DataSource.swift in Sources */,
 				ECD626F31D4DEFBC0040C7BF /* UIImageView.swift in Sources */,
-				16D30EF91D65D5FD00C2435D /* CALayer.swift in Sources */,
 				ECD626F11D4DEB490040C7BF /* UIDatePicker.swift in Sources */,
 				ECD627031D4DF5D40040C7BF /* UITextView.swift in Sources */,
 				ECD626EF1D4DEAB20040C7BF /* UIApplication.swift in Sources */,
-				EC8822071D421EA2006142ED /* NSObject.swift in Sources */,
+				EC877AB51E01CE9F00A23B51 /* ObservableDictionary.swift in Sources */,
+				EC877A981E01CE1200A23B51 /* NSLayoutConstraint.swift in Sources */,
 				ECD626FD1D4DF2D60040C7BF /* UISegmentedControl.swift in Sources */,
+				EC877A9E1E01CE1200A23B51 /* NSObject.swift in Sources */,
 				ECD626E91D4DE8800040C7BF /* UIActivityIndicatorView.swift in Sources */,
 				EC97EDAF1D6C51F0001C54C9 /* BNDProtocolProxyBase.m in Sources */,
-				1639C0801D6DD3190045959E /* ObservableArray.swift in Sources */,
 				EC2505B11D3F570500A6E14A /* UILabel.swift in Sources */,
+				EC877AB21E01CE9F00A23B51 /* ObservableArray.swift in Sources */,
 				ECD626ED1D4DE9BE0040C7BF /* UIBarButtonItem.swift in Sources */,
-				EC9693611D94613A004EB5EE /* Observable2DArray.swift in Sources */,
 				ECC4BE591D4A2E1600880DEC /* UIButton.swift in Sources */,
+				EC877A9B1E01CE1200A23B51 /* NSObject+KVO.swift in Sources */,
 				EC2D4A141DA8F36B00B03A6B /* NSObject+Bond.m in Sources */,
+				EC877AA11E01CE1200A23B51 /* SignalProtocol.swift in Sources */,
+				EC877AB81E01CE9F00A23B51 /* ObservableSet.swift in Sources */,
 				ECD626F51D4DF0E00040C7BF /* UINavigationBar.swift in Sources */,
 				ECD626F91D4DF1670040C7BF /* UIProgressView.swift in Sources */,
 				16559F831D64F4BC00EDD727 /* UITableView.swift in Sources */,
-				EC877A851E0194E700A23B51 /* SignalProtocol.swift in Sources */,
-				16D30EFD1D65D64600C2435D /* NSLayoutConstraint.swift in Sources */,
 				ECD626FF1D4DF34F0040C7BF /* UISlider.swift in Sources */,
 				EC2505B31D3F571500A6E14A /* UITextField.swift in Sources */,
 				EC35401C1D462F4700901AA1 /* UIControl.swift in Sources */,
 				1639C08A1D6DD39B0045959E /* Observable.swift in Sources */,
-				EC97ED9F1D6C500B001C54C9 /* NotificationCenter.swift in Sources */,
 				ECD626FB1D4DF1F50040C7BF /* UIRefreshControl.swift in Sources */,
-				EC97EDA31D6C50A5001C54C9 /* NSObject+KVO.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -850,34 +876,35 @@
 			files = (
 				16D30ECE1D659D4A00C2435D /* NSTextField.swift in Sources */,
 				16D30EBF1D65960B00C2435D /* Bond.swift in Sources */,
-				EC97EDAA1D6C51F0001C54C9 /* ProtocolProxy.swift in Sources */,
+				EC877A991E01CE1200A23B51 /* NSLayoutConstraint.swift in Sources */,
 				16D30EC61D659B8F00C2435D /* NSImageView.swift in Sources */,
+				EC877AB01E01CE9F00A23B51 /* Observable2DArray.swift in Sources */,
+				EC877AA21E01CE1200A23B51 /* SignalProtocol.swift in Sources */,
 				EC97EDB01D6C51F0001C54C9 /* BNDProtocolProxyBase.m in Sources */,
 				16D30F091D65D82D00C2435D /* NSAppearanceCustomization.swift in Sources */,
 				16D30F0B1D65E8C700C2435D /* NSTableView.swift in Sources */,
-				16D30EFE1D65D64600C2435D /* NSLayoutConstraint.swift in Sources */,
-				EC97EDA41D6C50A5001C54C9 /* NSObject+KVO.swift in Sources */,
+				EC877AB31E01CE9F00A23B51 /* ObservableArray.swift in Sources */,
+				EC877A961E01CE1200A23B51 /* NotificationCenter.swift in Sources */,
 				16D30EBC1D65944500C2435D /* NSButton.swift in Sources */,
 				EC2D4A151DA8F36B00B03A6B /* NSObject+Bond.m in Sources */,
-				1639C0841D6DD3190045959E /* ObservableDictionary.swift in Sources */,
+				EC877A931E01CE1200A23B51 /* CALayer.swift in Sources */,
 				16D30ECC1D659CA700C2435D /* NSSlider.swift in Sources */,
 				16D30ECA1D659C1200C2435D /* NSSegmentedControl.swift in Sources */,
 				16D30F051D65D7C000C2435D /* NSMenuItem.swift in Sources */,
+				EC877AB91E01CE9F00A23B51 /* ObservableSet.swift in Sources */,
 				16D30EC41D65988A00C2435D /* NSControl.swift in Sources */,
 				16D30F031D65D79600C2435D /* NSStatusBarButton.swift in Sources */,
-				EC97EDA01D6C500B001C54C9 /* NotificationCenter.swift in Sources */,
 				16D30ED01D659E0600C2435D /* NSView.swift in Sources */,
-				1639C0871D6DD3190045959E /* ObservableSet.swift in Sources */,
-				16D30EC21D65961300C2435D /* NSObject.swift in Sources */,
-				16D30EFA1D65D5FD00C2435D /* CALayer.swift in Sources */,
-				1639C0811D6DD3190045959E /* ObservableArray.swift in Sources */,
 				16D30F011D65D6AA00C2435D /* NSTextView.swift in Sources */,
 				16D30F071D65D7F800C2435D /* NSColorWell.swift in Sources */,
+				EC877AA71E01CE6100A23B51 /* ProtocolProxy.swift in Sources */,
 				1639C08B1D6DD39B0045959E /* Observable.swift in Sources */,
+				EC877AB61E01CE9F00A23B51 /* ObservableDictionary.swift in Sources */,
 				16D30EC11D65961000C2435D /* DataSource.swift in Sources */,
-				EC9693621D94613A004EB5EE /* Observable2DArray.swift in Sources */,
 				16D30EC01D65960E00C2435D /* DynamicSubject.swift in Sources */,
+				EC877A9F1E01CE1200A23B51 /* NSObject.swift in Sources */,
 				16D30EC81D659BDB00C2435D /* NSProgressIndicator.swift in Sources */,
+				EC877A9C1E01CE1200A23B51 /* NSObject+KVO.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -885,43 +912,44 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1639C0851D6DD3190045959E /* ObservableDictionary.swift in Sources */,
 				16D30EF71D65D16600C2435D /* UICollectionView.swift in Sources */,
+				EC877AA01E01CE1200A23B51 /* NSObject.swift in Sources */,
 				16D30EED1D65D16600C2435D /* UINavigationItem.swift in Sources */,
-				EC97EDAB1D6C51F0001C54C9 /* ProtocolProxy.swift in Sources */,
+				EC877A971E01CE1200A23B51 /* NotificationCenter.swift in Sources */,
+				EC877AA31E01CE1200A23B51 /* SignalProtocol.swift in Sources */,
 				16D30EF21D65D16600C2435D /* UISwitch.swift in Sources */,
 				16D30EF31D65D16600C2435D /* UITextField.swift in Sources */,
 				16D30EF41D65D16600C2435D /* UITextView.swift in Sources */,
-				1639C0881D6DD3190045959E /* ObservableSet.swift in Sources */,
 				16D30EE41D65D16600C2435D /* UIApplication.swift in Sources */,
 				16D30EF61D65D16600C2435D /* UITableView.swift in Sources */,
+				EC877AB71E01CE9F00A23B51 /* ObservableDictionary.swift in Sources */,
 				16D30EEB1D65D16600C2435D /* UILabel.swift in Sources */,
+				EC877AB11E01CE9F00A23B51 /* Observable2DArray.swift in Sources */,
+				EC877AB41E01CE9F00A23B51 /* ObservableArray.swift in Sources */,
 				16D30EE81D65D16600C2435D /* UIControl.swift in Sources */,
-				16D30EFB1D65D5FD00C2435D /* CALayer.swift in Sources */,
 				16D30EF51D65D16600C2435D /* UIView.swift in Sources */,
 				16D30EE31D65D16600C2435D /* UIActivityIndicatorView.swift in Sources */,
 				16D30EE11D65D14C00C2435D /* DataSource.swift in Sources */,
 				16D30EEA1D65D16600C2435D /* UIImageView.swift in Sources */,
-				16D30EE21D65D14C00C2435D /* NSObject.swift in Sources */,
 				16D30EF01D65D16600C2435D /* UISegmentedControl.swift in Sources */,
 				EC97EDB11D6C51F0001C54C9 /* BNDProtocolProxyBase.m in Sources */,
-				1639C0821D6DD3190045959E /* ObservableArray.swift in Sources */,
 				16D30EE61D65D16600C2435D /* UIBarItem.swift in Sources */,
 				16D30EE51D65D16600C2435D /* UIBarButtonItem.swift in Sources */,
-				EC9693631D94613A004EB5EE /* Observable2DArray.swift in Sources */,
 				16D30EE01D65D14C00C2435D /* DynamicSubject.swift in Sources */,
+				EC877A9A1E01CE1200A23B51 /* NSLayoutConstraint.swift in Sources */,
 				16D30EDF1D65D14C00C2435D /* Bond.swift in Sources */,
 				16D30EEC1D65D16600C2435D /* UINavigationBar.swift in Sources */,
 				16D30EEE1D65D16600C2435D /* UIProgressView.swift in Sources */,
-				16D30EFF1D65D64600C2435D /* NSLayoutConstraint.swift in Sources */,
+				EC877A9D1E01CE1200A23B51 /* NSObject+KVO.swift in Sources */,
 				16D30EF11D65D16600C2435D /* UISlider.swift in Sources */,
 				16D30EE91D65D16600C2435D /* UIDatePicker.swift in Sources */,
+				EC877ABA1E01CE9F00A23B51 /* ObservableSet.swift in Sources */,
+				EC877AA81E01CE6100A23B51 /* ProtocolProxy.swift in Sources */,
 				16D30EE71D65D16600C2435D /* UIButton.swift in Sources */,
 				1639C08C1D6DD39B0045959E /* Observable.swift in Sources */,
-				EC97EDA11D6C500B001C54C9 /* NotificationCenter.swift in Sources */,
+				EC877A941E01CE1200A23B51 /* CALayer.swift in Sources */,
 				EC2D4A161DA8F36B00B03A6B /* NSObject+Bond.m in Sources */,
 				16D30EEF1D65D16600C2435D /* UIRefreshControl.swift in Sources */,
-				EC97EDA51D6C50A5001C54C9 /* NSObject+KVO.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		16D30F071D65D7F800C2435D /* NSColorWell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F061D65D7F800C2435D /* NSColorWell.swift */; };
 		16D30F091D65D82D00C2435D /* NSAppearanceCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F081D65D82C00C2435D /* NSAppearanceCustomization.swift */; };
 		16D30F0B1D65E8C700C2435D /* NSTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F0A1D65E8C700C2435D /* NSTableView.swift */; };
+		1F5F73AD1E267BC10001E3CC /* Observable2DArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F73AC1E267BC10001E3CC /* Observable2DArrayTests.swift */; };
 		227DEF051DCB87BF00213852 /* UIGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227DEF041DCB87BF00213852 /* UIGestureRecognizer.swift */; };
 		90A3FACD1E0C8D9A0086A7F1 /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
 		90A3FACE1E0C8D9F0086A7F1 /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
@@ -275,6 +276,7 @@
 		16D30F061D65D7F800C2435D /* NSColorWell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSColorWell.swift; sourceTree = "<group>"; };
 		16D30F081D65D82C00C2435D /* NSAppearanceCustomization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAppearanceCustomization.swift; sourceTree = "<group>"; };
 		16D30F0A1D65E8C700C2435D /* NSTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTableView.swift; sourceTree = "<group>"; };
+		1F5F73AC1E267BC10001E3CC /* Observable2DArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable2DArrayTests.swift; sourceTree = "<group>"; };
 		227DEF041DCB87BF00213852 /* UIGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIGestureRecognizer.swift; sourceTree = "<group>"; };
 		90A3FAC21E0C8D8B0086A7F1 /* Diff.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Diff.xcodeproj; path = Carthage/Checkouts/Diff.swift/Diff.xcodeproj; sourceTree = "<group>"; };
 		EC06A8751DBCB147006AEA81 /* NSObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObjectTests.swift; sourceTree = "<group>"; };
@@ -431,6 +433,7 @@
 				ECCF8A571D9007AF00575DA8 /* BondTests.swift */,
 				ECD594091D93EC9700C840C2 /* DynamicSubjectTests.swift */,
 				ECCF8A511D8FFEF300575DA8 /* ObservableArrayTests.swift */,
+				1F5F73AC1E267BC10001E3CC /* Observable2DArrayTests.swift */,
 				16887E2F1D74499A00EDA099 /* ProtocolProxyTests.swift */,
 				16210A4A1D3EC474004AEDF3 /* UIKitTests.swift */,
 				EC96935A1D943B15004EB5EE /* UITableViewTests.swift */,
@@ -905,6 +908,7 @@
 				16887E301D74499A00EDA099 /* ProtocolProxyTests.swift in Sources */,
 				ECD5940A1D93EC9700C840C2 /* DynamicSubjectTests.swift in Sources */,
 				EC06A8761DBCB147006AEA81 /* NSObjectTests.swift in Sources */,
+				1F5F73AD1E267BC10001E3CC /* Observable2DArrayTests.swift in Sources */,
 				ECCF8A581D9007AF00575DA8 /* BondTests.swift in Sources */,
 				EC96935B1D943B15004EB5EE /* UITableViewTests.swift in Sources */,
 				16887E321D744A1400EDA099 /* Helpers.swift in Sources */,

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		EC7890EF1D44F1BF002848EB /* Bond.h in Headers */ = {isa = PBXBuildFile; fileRef = EC7890ED1D44F1BF002848EB /* Bond.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EC7890F21D44F1D9002848EB /* Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7890F11D44F1D9002848EB /* Bond.swift */; };
 		EC7890F41D44F1ED002848EB /* DynamicSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7890F31D44F1ED002848EB /* DynamicSubject.swift */; };
+		EC877A851E0194E700A23B51 /* SignalProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC877A841E0194E700A23B51 /* SignalProtocol.swift */; };
 		EC8822071D421EA2006142ED /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8822061D421EA2006142ED /* NSObject.swift */; };
 		EC96935B1D943B15004EB5EE /* UITableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC96935A1D943B15004EB5EE /* UITableViewTests.swift */; };
 		EC96935F1D945CC6004EB5EE /* UICollectionViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC96935E1D945CC6004EB5EE /* UICollectionViewTests.swift */; };
@@ -271,6 +272,7 @@
 		EC7890EE1D44F1BF002848EB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Bond/Info.plist; sourceTree = "<group>"; };
 		EC7890F11D44F1D9002848EB /* Bond.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bond.swift; sourceTree = "<group>"; };
 		EC7890F31D44F1ED002848EB /* DynamicSubject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DynamicSubject.swift; sourceTree = "<group>"; };
+		EC877A841E0194E700A23B51 /* SignalProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignalProtocol.swift; sourceTree = "<group>"; };
 		EC8822061D421EA2006142ED /* NSObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NSObject.swift; path = Sources/NSObject.swift; sourceTree = SOURCE_ROOT; };
 		EC96935A1D943B15004EB5EE /* UITableViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITableViewTests.swift; sourceTree = "<group>"; };
 		EC96935E1D945CC6004EB5EE /* UICollectionViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICollectionViewTests.swift; sourceTree = "<group>"; };
@@ -397,6 +399,7 @@
 				16D30EF81D65D5FD00C2435D /* CALayer.swift */,
 				16D30EFC1D65D64600C2435D /* NSLayoutConstraint.swift */,
 				EC97ED9E1D6C500B001C54C9 /* NotificationCenter.swift */,
+				EC877A841E0194E700A23B51 /* SignalProtocol.swift */,
 				EC97EDA71D6C51F0001C54C9 /* BNDProtocolProxyBase.h */,
 				EC97EDA81D6C51F0001C54C9 /* BNDProtocolProxyBase.m */,
 				EC2D4A0D1DA8F31700B03A6B /* NSObject+Bond.h */,
@@ -805,6 +808,7 @@
 				ECD626F51D4DF0E00040C7BF /* UINavigationBar.swift in Sources */,
 				ECD626F91D4DF1670040C7BF /* UIProgressView.swift in Sources */,
 				16559F831D64F4BC00EDD727 /* UITableView.swift in Sources */,
+				EC877A851E0194E700A23B51 /* SignalProtocol.swift in Sources */,
 				16D30EFD1D65D64600C2435D /* NSLayoutConstraint.swift in Sources */,
 				ECD626FF1D4DF34F0040C7BF /* UISlider.swift in Sources */,
 				EC2505B31D3F571500A6E14A /* UITextField.swift in Sources */,

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -285,6 +285,7 @@
 		EC2D4A0D1DA8F31700B03A6B /* NSObject+Bond.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSObject+Bond.h"; path = "Bond/NSObject+Bond.h"; sourceTree = SOURCE_ROOT; };
 		EC2D4A131DA8F36B00B03A6B /* NSObject+Bond.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+Bond.m"; path = "Bond/NSObject+Bond.m"; sourceTree = SOURCE_ROOT; };
 		EC35401B1D462F4700901AA1 /* UIControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIControl.swift; sourceTree = "<group>"; };
+		EC378E961E13FFD100E2197D /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		EC7890ED1D44F1BF002848EB /* Bond.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Bond.h; path = Bond/Bond.h; sourceTree = "<group>"; };
 		EC7890EE1D44F1BF002848EB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Bond/Info.plist; sourceTree = "<group>"; };
 		EC7890F11D44F1D9002848EB /* Bond.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bond.swift; sourceTree = "<group>"; };
@@ -376,6 +377,7 @@
 			children = (
 				ECD5940B1D93F2E400C840C2 /* Cartfile */,
 				ECD5940C1D93F2ED00C840C2 /* Bond.podspec */,
+				EC378E961E13FFD100E2197D /* Package.swift */,
 				161D6D2D1D6F0D92004CA17D /* README.md */,
 				EC7890ED1D44F1BF002848EB /* Bond.h */,
 				EC7890EE1D44F1BF002848EB /* Info.plist */,

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -84,6 +84,9 @@
 		16D30F091D65D82D00C2435D /* NSAppearanceCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F081D65D82C00C2435D /* NSAppearanceCustomization.swift */; };
 		16D30F0B1D65E8C700C2435D /* NSTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F0A1D65E8C700C2435D /* NSTableView.swift */; };
 		227DEF051DCB87BF00213852 /* UIGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227DEF041DCB87BF00213852 /* UIGestureRecognizer.swift */; };
+		90A3FACD1E0C8D9A0086A7F1 /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
+		90A3FACE1E0C8D9F0086A7F1 /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
+		90A3FACF1E0C8DA20086A7F1 /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
 		EC06A8761DBCB147006AEA81 /* NSObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC06A8751DBCB147006AEA81 /* NSObjectTests.swift */; };
 		EC2505B11D3F570500A6E14A /* UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2505B01D3F570500A6E14A /* UILabel.swift */; };
 		EC2505B31D3F571500A6E14A /* UITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2505B21D3F571500A6E14A /* UITextField.swift */; };
@@ -220,6 +223,20 @@
 			remoteGlobalIDString = 16887E361D744ABB00EDA099;
 			remoteInfo = "Bond-App";
 		};
+		90A3FAC71E0C8D8B0086A7F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90A3FAC21E0C8D8B0086A7F1 /* Diff.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C9EE87161CCFCA83006BD90E;
+			remoteInfo = Diff;
+		};
+		90A3FAC91E0C8D8B0086A7F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90A3FAC21E0C8D8B0086A7F1 /* Diff.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = C9838FF11D29571000691BE8;
+			remoteInfo = DiffTests;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -261,6 +278,7 @@
 		16D30F081D65D82C00C2435D /* NSAppearanceCustomization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAppearanceCustomization.swift; sourceTree = "<group>"; };
 		16D30F0A1D65E8C700C2435D /* NSTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTableView.swift; sourceTree = "<group>"; };
 		227DEF041DCB87BF00213852 /* UIGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIGestureRecognizer.swift; sourceTree = "<group>"; };
+		90A3FAC21E0C8D8B0086A7F1 /* Diff.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Diff.xcodeproj; path = Carthage/Checkouts/Diff.swift/Diff.xcodeproj; sourceTree = "<group>"; };
 		EC06A8751DBCB147006AEA81 /* NSObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObjectTests.swift; sourceTree = "<group>"; };
 		EC2505B01D3F570500A6E14A /* UILabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UILabel.swift; path = Sources/UIKit/UILabel.swift; sourceTree = SOURCE_ROOT; };
 		EC2505B21D3F571500A6E14A /* UITextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UITextField.swift; path = Sources/UIKit/UITextField.swift; sourceTree = SOURCE_ROOT; };
@@ -309,6 +327,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				90A3FACD1E0C8D9A0086A7F1 /* Diff.framework in Frameworks */,
 				165217961D70593E00C9FAEE /* ReactiveKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -335,6 +354,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				90A3FACE1E0C8D9F0086A7F1 /* Diff.framework in Frameworks */,
 				165217991D70594D00C9FAEE /* ReactiveKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -343,6 +363,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				90A3FACF1E0C8DA20086A7F1 /* Diff.framework in Frameworks */,
 				1652179C1D70595600C9FAEE /* ReactiveKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -362,6 +383,7 @@
 				16210A491D3EC474004AEDF3 /* BondTests */,
 				16887E381D744ABB00EDA099 /* Bond-App */,
 				16210A3D1D3EC474004AEDF3 /* Products */,
+				90A3FAC21E0C8D8B0086A7F1 /* Diff.xcodeproj */,
 				165217821D70591D00C9FAEE /* ReactiveKit.xcodeproj */,
 			);
 			indentWidth = 2;
@@ -465,6 +487,15 @@
 				16D30F0A1D65E8C700C2435D /* NSTableView.swift */,
 			);
 			path = AppKit;
+			sourceTree = "<group>";
+		};
+		90A3FAC31E0C8D8B0086A7F1 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */,
+				90A3FACA1E0C8D8B0086A7F1 /* DiffTests.xctest */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 		EC2505AF1D3F56D900A6E14A /* UIKit */ = {
@@ -677,6 +708,10 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
+					ProductGroup = 90A3FAC31E0C8D8B0086A7F1 /* Products */;
+					ProjectRef = 90A3FAC21E0C8D8B0086A7F1 /* Diff.xcodeproj */;
+				},
+				{
 					ProductGroup = 165217831D70591D00C9FAEE /* Products */;
 					ProjectRef = 165217821D70591D00C9FAEE /* ReactiveKit.xcodeproj */;
 				},
@@ -726,6 +761,20 @@
 			fileType = wrapper.cfbundle;
 			path = "ReactiveKit-Tests.xctest";
 			remoteRef = 165217921D70591E00C9FAEE /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Diff.framework;
+			remoteRef = 90A3FAC71E0C8D8B0086A7F1 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		90A3FACA1E0C8D8B0086A7F1 /* DiffTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = DiffTests.xctest;
+			remoteRef = 90A3FAC91E0C8D8B0086A7F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/Bond/Info.plist
+++ b/Bond/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.1.1</string>
+	<string>6.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Bond/Info.plist
+++ b/Bond/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.1.0</string>
+	<string>5.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Bond/Info.plist
+++ b/Bond/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.3.1</string>
+	<string>5.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/BondTests/BondTests.swift
+++ b/BondTests/BondTests.swift
@@ -19,11 +19,11 @@ class BondTypeTests: XCTestCase {
   // Update closure is called on each next element
   func testExecutes() {
     let target = DummyTarget()
-    let bond = Bond<DummyTarget, Int>(target: target) { target, element in
+    let bond = Bond<Int>(target: target) { target, element in
       target.recordedElements.append(element)
     }
     
-    Signal1.sequence([1, 2, 3]).bind(to: bond)
+    SafeSignal.sequence([1, 2, 3]).bind(to: bond)
     XCTAssert(target.recordedElements == [1, 2, 3])
   }
   
@@ -33,7 +33,7 @@ class BondTypeTests: XCTestCase {
     var target: DummyTarget! = DummyTarget()
     weak var weakTarget = target
     
-    let bond = Bond<DummyTarget, Int>(target: target) { target, element in
+    let bond = Bond<Int>(target: target) { target, element in
       target.recordedElements.append(element)
     }
     

--- a/BondTests/DynamicSubjectTests.swift
+++ b/BondTests/DynamicSubjectTests.swift
@@ -39,7 +39,7 @@ class DynamicSubjectTests: XCTestCase {
     subject.on(.next(7))
     XCTAssert(target.value == 7)
     
-    Signal1.sequence([1, 2, 3]).bind(to: subject)
+    SafeSignal.sequence([1, 2, 3]).bind(to: subject)
     XCTAssert(target.recordedElements == [7, 1, 2, 3])
     XCTAssert(target.value == 3)
   }

--- a/BondTests/NSObjectTests.swift
+++ b/BondTests/NSObjectTests.swift
@@ -23,7 +23,7 @@ class NSObjectTests: XCTestCase {
   }
 
   func testBndDeallocated() {
-    object.bnd_deallocated.expect([.completed], expectation: expectation(description: #function))
+    object.deallocated.expect([.completed], expectation: expectation(description: #function))
     object = nil
     waitForExpectations(timeout: 1)
   }
@@ -31,8 +31,8 @@ class NSObjectTests: XCTestCase {
   func testBndBag() {
     let d1 = SimpleDisposable()
     let d2 = SimpleDisposable()
-    object.bnd_bag.add(disposable: d1)
-    d2.disposeIn(object.bnd_bag)
+    object.reactive.bag.add(disposable: d1)
+    d2.disposeIn(object.reactive.bag)
     object = nil
     XCTAssert(d1.isDisposed)
     XCTAssert(d2.isDisposed)
@@ -53,23 +53,23 @@ class NSObjectKVOTests: XCTestCase {
   }
 
   func testObservation() {
-    let subject = object.dynamic(keyPath: "property", ofType: String.self)
+    let subject = object.reactive.keyPath("property", ofType: String.self)
     subject.expectNext(["a", "b", "c"])
     object.property = "b"
     object.property = "c"
   }
 
   func testBinding() {
-    let subject = object.dynamic(keyPath: "property", ofType: String.self)
+    let subject = object.reactive.keyPath("property", ofType: String.self)
     subject.expectNext(["a", "b", "c"])
-    Signal1.just("b").bind(to: subject)
+    SafeSignal.just("b").bind(to: subject)
     XCTAssert((object.property as! String) == "b")
-    Signal1.just("c").bind(to: subject)
+    SafeSignal.just("c").bind(to: subject)
     XCTAssert((object.property as! String) == "c")
   }
 
   func testOptionalObservation() {
-    let subject = object.dynamic(keyPath: "property", ofType: Optional<String>.self)
+    let subject = object.reactive.keyPath("property", ofType: Optional<String>.self)
     subject.expectNext(["a", "b", nil, "c"])
     object.property = "b"
     object.property = nil
@@ -77,40 +77,40 @@ class NSObjectKVOTests: XCTestCase {
   }
 
   func testOptionalBinding() {
-    let subject = object.dynamic(keyPath: "property", ofType: Optional<String>.self)
+    let subject = object.reactive.keyPath("property", ofType: Optional<String>.self)
     subject.expectNext(["a", "b", nil, "c"])
-    Signal1.just("b").bind(to: subject)
+    SafeSignal.just("b").bind(to: subject)
     XCTAssert((object.property as! String) == "b")
-    Signal1.just(nil).bind(to: subject)
+    SafeSignal.just(nil).bind(to: subject)
     XCTAssert(object.property == nil)
-    Signal1.just("c").bind(to: subject)
+    SafeSignal.just("c").bind(to: subject)
     XCTAssert((object.property as! String) == "c")
   }
 
   func testExpectedTypeObservation() {
-    let subject = object.dynamic(keyPath: "property", ofExpectedType: String.self)
+    let subject = object.reactive.keyPath("property", ofExpectedType: String.self)
     subject.expectNext(["a", "b", "c"])
     object.property = "b"
     object.property = "c"
   }
 
   func testExpectedTypeBinding() {
-    let subject = object.dynamic(keyPath: "property", ofExpectedType: String.self)
+    let subject = object.reactive.keyPath("property", ofExpectedType: String.self)
     subject.expectNext(["a", "b", "c"])
-    Signal1.just("b").bind(to: subject)
+    SafeSignal.just("b").bind(to: subject)
     XCTAssert((object.property as! String) == "b")
-    Signal1.just("c").bind(to: subject)
+    SafeSignal.just("c").bind(to: subject)
     XCTAssert((object.property as! String) == "c")
   }
 
   func testExpectedTypeFailure() {
-    let subject = object.dynamic(keyPath: "property", ofExpectedType: String.self)
+    let subject = object.reactive.keyPath("property", ofExpectedType: String.self)
     subject.expect([.next("a"), .failed(.notConvertible(""))])
     object.property = 5
   }
 
   func testExpectedTypeOptionalObservation() {
-    let subject = object.dynamic(keyPath: "property", ofExpectedType: Optional<String>.self)
+    let subject = object.reactive.keyPath("property", ofExpectedType: Optional<String>.self)
     subject.expectNext(["a", "b", nil, "c"])
     object.property = "b"
     object.property = nil
@@ -118,24 +118,24 @@ class NSObjectKVOTests: XCTestCase {
   }
 
   func testExpectedTypeOptionalBinding() {
-    let subject = object.dynamic(keyPath: "property", ofExpectedType: Optional<String>.self)
+    let subject = object.reactive.keyPath("property", ofExpectedType: Optional<String>.self)
     subject.expectNext(["a", "b", nil, "c"])
-    Signal1.just("b").bind(to: subject)
+    SafeSignal.just("b").bind(to: subject)
     XCTAssert((object.property as! String) == "b")
-    Signal1.just(nil).bind(to: subject)
+    SafeSignal.just(nil).bind(to: subject)
     XCTAssert(object.property == nil)
-    Signal1.just("c").bind(to: subject)
+    SafeSignal.just("c").bind(to: subject)
     XCTAssert((object.property as! String) == "c")
   }
 
   func testExpectedTypeOptionalFailure() {
-    let subject = object.dynamic(keyPath: "property", ofExpectedType: Optional<String>.self)
+    let subject = object.reactive.keyPath("property", ofExpectedType: Optional<String>.self)
     subject.expect([.next("a"), .failed(.notConvertible(""))])
     object.property = 5
   }
 
   func testDeallocation() {
-    let subject = object.dynamic(keyPath: "property", ofExpectedType: String.self)
+    let subject = object.reactive.keyPath("property", ofExpectedType: String.self)
     subject.expect([.next("a"), .completed], expectation: expectation(description: #function))
     weak var weakObject = object
     object = nil

--- a/BondTests/NSObjectTests.swift
+++ b/BondTests/NSObjectTests.swift
@@ -32,7 +32,7 @@ class NSObjectTests: XCTestCase {
     let d1 = SimpleDisposable()
     let d2 = SimpleDisposable()
     object.reactive.bag.add(disposable: d1)
-    d2.disposeIn(object.reactive.bag)
+    d2.dispose(in: object.reactive.bag)
     object = nil
     XCTAssert(d1.isDisposed)
     XCTAssert(d2.isDisposed)

--- a/BondTests/Observable2DArrayTests.swift
+++ b/BondTests/Observable2DArrayTests.swift
@@ -1,0 +1,48 @@
+//
+//  Observable2DArrayTests.swift
+//  Bond
+//
+//  Created by MOHAMMAD TAWEEL on 1/11/17.
+//  Copyright © 2017 Swift Bond. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+@testable import Bond
+
+class Observable2DArrayTests: XCTestCase {
+  
+  var array2D: MutableObservable2DArray<String,Int>!
+  
+  override func setUp() {
+    super.setUp()
+    array2D = MutableObservable2DArray([
+      Observable2DArraySection(metadata: "units", items: [1,2,3]),
+      Observable2DArraySection(metadata: "tens", items: [10,20,30]),
+      Observable2DArraySection(metadata: "hundreds", items: [100,200,300]),
+      Observable2DArraySection(metadata: "thousands", items: [1000,2000,3000]),
+    ])
+  }
+  
+  func testReplace2D() {
+    
+    let newArray = MutableObservable2DArray([
+      Observable2DArraySection(metadata: "tens", items: [10,30]),
+      Observable2DArraySection(metadata: "hundreds", items: [100,200,400]),
+      Observable2DArraySection(metadata: "hundredssss", items: [100,200,400]),
+      Observable2DArraySection(metadata: "units", items: [4,3,2]),
+      ])
+    
+    array2D.replace2D(with: newArray, performDiff: true)
+    print(array2D)
+//    array.expectNext([
+//      ObservableArrayEvent(change: .reset, source: array),
+//      ObservableArrayEvent(change: .inserts([3]), source: array)
+//      ])
+//    
+//    array.append(4)
+//    XCTAssert(array == ObservableArray([1, 2, 3, 4]))
+}
+
+}

--- a/BondTests/UIKitTests.swift
+++ b/BondTests/UIKitTests.swift
@@ -15,19 +15,19 @@ class BondTests: XCTestCase {
   func testUIView() {
     let view = UIView()
 
-    Signal1.just(UIColor.red).bind(to: view.bnd_backgroundColor)
+    SafeSignal.just(UIColor.red).bind(to: view.reactive.backgroundColor)
     XCTAssertEqual(view.backgroundColor!, UIColor.red)
 
-    Signal1.just(0.3).bind(to: view.bnd_alpha)
+    SafeSignal.just(0.3).bind(to: view.reactive.alpha)
     XCTAssertEqual(view.alpha, 0.3)
 
-    Signal1.just(true).bind(to: view.bnd_isHidden)
+    SafeSignal.just(true).bind(to: view.reactive.isHidden)
     XCTAssertEqual(view.isHidden, true)
 
-    Signal1.just(true).bind(to: view.bnd_isUserInteractionEnabled)
+    SafeSignal.just(true).bind(to: view.reactive.isUserInteractionEnabled)
     XCTAssertEqual(view.isUserInteractionEnabled, true)
 
-    Signal1.just(UIColor.red).bind(to: view.bnd_tintColor)
+    SafeSignal.just(UIColor.red).bind(to: view.reactive.tintColor)
     XCTAssertEqual(view.tintColor, UIColor.red)
   }
 
@@ -35,7 +35,7 @@ class BondTests: XCTestCase {
     let subject = PublishSubject1<Bool>()
 
     let view = UIActivityIndicatorView()
-    subject.bind(to: view.bnd_animating)
+    subject.bind(to: view.reactive.animating)
 
     XCTAssertEqual(view.isAnimating, false)
 
@@ -49,20 +49,20 @@ class BondTests: XCTestCase {
   func testUIBarItem() {
     let view = UIBarButtonItem()
 
-    Signal1.just("test").bind(to: view.bnd_title)
+    SafeSignal.just("test").bind(to: view.reactive.title)
     XCTAssertEqual(view.title!, "test")
 
     let image = UIImage()
-    Signal1.just(image).bind(to: view.bnd_image)
+    SafeSignal.just(image).bind(to: view.reactive.image)
     XCTAssertEqual(view.image!, image)
 
-    Signal1.just(true).bind(to: view.bnd_isEnabled)
+    SafeSignal.just(true).bind(to: view.reactive.isEnabled)
     XCTAssertEqual(view.isEnabled, true)
-    Signal1.just(false).bind(to: view.bnd_isEnabled)
+    SafeSignal.just(false).bind(to: view.reactive.isEnabled)
     XCTAssertEqual(view.isEnabled, false)
 
-    view.bnd_tap.expectNext([(), ()])
-    view.bnd_tap.expectNext([(), ()]) // second observer
+    view.reactive.tap.expectNext([(), ()])
+    view.reactive.tap.expectNext([(), ()]) // second observer
     _ = view.target!.perform(view.action!)
     _ = view.target!.perform(view.action!)
   }
@@ -70,20 +70,20 @@ class BondTests: XCTestCase {
   func testUIButton() {
     let view = UIButton()
     
-    Signal1.just("test").bind(to: view.bnd_title)
+    SafeSignal.just("test").bind(to: view.reactive.title)
     XCTAssertEqual(view.titleLabel?.text, "test")
     
-    Signal1.just(true).bind(to: view.bnd_isSelected)
+    SafeSignal.just(true).bind(to: view.reactive.isSelected)
     XCTAssertEqual(view.isSelected, true)
-    Signal1.just(false).bind(to: view.bnd_isSelected)
+    SafeSignal.just(false).bind(to: view.reactive.isSelected)
     XCTAssertEqual(view.isSelected, false)
     
-    Signal1.just(true).bind(to: view.bnd_isHighlighted)
+    SafeSignal.just(true).bind(to: view.reactive.isHighlighted)
     XCTAssertEqual(view.isHighlighted, true)
-    Signal1.just(false).bind(to: view.bnd_isHighlighted)
+    SafeSignal.just(false).bind(to: view.reactive.isHighlighted)
     XCTAssertEqual(view.isHighlighted, false)
     
-    view.bnd_tap.expectNext([(), ()])
+    view.reactive.tap.expectNext([(), ()])
     view.sendActions(for: .touchUpInside)
     view.sendActions(for: .touchUpInside)
     view.sendActions(for: .touchUpOutside)
@@ -92,12 +92,12 @@ class BondTests: XCTestCase {
   func testUIControl() {
     let view = UIControl()
     
-    Signal1.just(true).bind(to: view.bnd_isEnabled)
+    SafeSignal.just(true).bind(to: view.reactive.isEnabled)
     XCTAssertEqual(view.isEnabled, true)
-    Signal1.just(false).bind(to: view.bnd_isEnabled)
+    SafeSignal.just(false).bind(to: view.reactive.isEnabled)
     XCTAssertEqual(view.isEnabled, false)
     
-    view.bnd_controlEvents(UIControlEvents.touchUpInside).expectNext([(), ()])
+    view.reactive.controlEvents(UIControlEvents.touchUpInside).expectNext([(), ()])
     view.sendActions(for: .touchUpInside)
     view.sendActions(for: .touchUpOutside)
     view.sendActions(for: .touchUpInside)
@@ -118,7 +118,7 @@ class BondTests: XCTestCase {
     subject.next(date2)
     XCTAssertEqual(view.date, date2)
     
-    view.bnd_date.expectNext([date2, date1])
+    view.reactive.date.expectNext([date2, date1])
     view.date = date1
     view.sendActions(for: .valueChanged)
   }
@@ -162,7 +162,7 @@ class BondTests: XCTestCase {
     let subject = PublishSubject1<UIColor?>()
     
     let view = UINavigationBar()
-    subject.bind(to: view.bnd_barTintColor)
+    subject.bind(to: view.reactive.barTintColor)
     
     subject.next(.red)
     XCTAssertEqual(view.barTintColor!, .red)
@@ -179,7 +179,7 @@ class BondTests: XCTestCase {
     let subject = PublishSubject1<String?>()
     
     let view = UINavigationItem()
-    subject.bind(to: view.bnd_title)
+    subject.bind(to: view.reactive.title)
     
     subject.next("a")
     XCTAssertEqual(view.title!, "a")
@@ -216,7 +216,7 @@ class BondTests: XCTestCase {
     subject.next(false)
     XCTAssertEqual(view.isRefreshing, false)
 
-    view.bnd_refreshing.expectNext([false, true])
+    view.reactive.refreshing.expectNext([false, true])
     view.beginRefreshing()
     view.sendActions(for: .valueChanged)
   }
@@ -233,7 +233,7 @@ class BondTests: XCTestCase {
     subject.next(0)
     XCTAssertEqual(view.selectedSegmentIndex, 0)
 
-    view.bnd_selectedSegmentIndex.expectNext([0, 1])
+    view.reactive.selectedSegmentIndex.expectNext([0, 1])
     view.selectedSegmentIndex = 1
     view.sendActions(for: .valueChanged)
   }
@@ -250,7 +250,7 @@ class BondTests: XCTestCase {
     subject.next(0.4)
     XCTAssertEqual(view.value, 0.4)
 
-    view.bnd_value.expectNext([0.4, 0.6])
+    view.reactive.value.expectNext([0.4, 0.6])
     view.value = 0.6
     view.sendActions(for: .valueChanged)
   }
@@ -267,7 +267,7 @@ class BondTests: XCTestCase {
     subject.next(true)
     XCTAssertEqual(view.isOn, true)
 
-    view.bnd_isOn.expectNext([true, false])
+    view.reactive.isOn.expectNext([true, false])
     view.isOn = false
     view.sendActions(for: .valueChanged)
   }
@@ -284,7 +284,7 @@ class BondTests: XCTestCase {
     subject.next("b")
     XCTAssertEqual(view.text!, "b")
 
-    view.bnd_text.expectNext(["b", "c"])
+    view.reactive.text.expectNext(["b", "c"])
     view.text = "c"
     view.sendActions(for: .allEditingEvents)
   }
@@ -301,7 +301,7 @@ class BondTests: XCTestCase {
     subject.next("b")
     XCTAssertEqual(view.text!, "b")
 
-    view.bnd_text.expectNext(["b", "c"])
+    view.reactive.text.expectNext(["b", "c"])
     view.text = "c"
     NotificationCenter.default.post(name: NSNotification.Name.UITextViewTextDidChange, object: view)
   }

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "ReactiveKit/ReactiveKit" "develop"
+github "ReactiveKit/ReactiveKit" ~> v3.2
 github "wokalski/Diff.swift" ~> 0.4

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "ReactiveKit/ReactiveKit" ~> 3.1.2
+github "ReactiveKit/ReactiveKit" ~> 3.2
 github "wokalski/Diff.swift" ~> 0.4

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "ReactiveKit/ReactiveKit" ~> 3.1
+github "ReactiveKit/ReactiveKit" ~> 3.1.2
 github "wokalski/Diff.swift" ~> 0.4

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "ReactiveKit/ReactiveKit" ~> 3.2
+github "ReactiveKit/ReactiveKit" "develop"
 github "wokalski/Diff.swift" ~> 0.4

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "ReactiveKit/ReactiveKit" ~> 3.2
-github "wokalski/Diff.swift" ~> 0.4
+github "wokalski/Diff.swift"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
 github "ReactiveKit/ReactiveKit" ~> 3.1
+github "wokalski/Diff.swift" ~> 0.4

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "ReactiveKit/ReactiveKit" ~> v3.2
+github "ReactiveKit/ReactiveKit" ~> 3.2
 github "wokalski/Diff.swift" ~> 0.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "wokalski/Diff.swift" "0.4.1"
-github "ReactiveKit/ReactiveKit" "v3.1.2"
+github "wokalski/Diff.swift" "0.4.2"
+github "ReactiveKit/ReactiveKit" "854494efeb4276d942c63d85901997ad6400865e"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "wokalski/Diff.swift" "0.4.2"
+github "wokalski/Diff.swift" "0.5.0"
 github "ReactiveKit/ReactiveKit" "v3.2.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "ReactiveKit/ReactiveKit" "v3.0.0-beta6"
-github "wokalski/Diff.swift" "0.4"
+github "wokalski/Diff.swift" "0.4.1"
+github "ReactiveKit/ReactiveKit" "v3.1.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "wokalski/Diff.swift" "0.4.2"
-github "ReactiveKit/ReactiveKit" "854494efeb4276d942c63d85901997ad6400865e"
+github "ReactiveKit/ReactiveKit" "v3.2.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
 github "ReactiveKit/ReactiveKit" "v3.0.0-beta6"
+github "wokalski/Diff.swift" "0.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "wokalski/Diff.swift" "0.5.0"
+github "wokalski/Diff.swift" "0.5.1"
 github "ReactiveKit/ReactiveKit" "v3.2.1"

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "Bond",
     dependencies: [
-        .Package(url: "https://github.com/ReactiveKit/ReactiveKit.git", versions: Version(3, 0, 0, prereleaseIdentifiers: ["beta"])..<Version(4, 0, 0))
+        .Package(url: "https://github.com/ReactiveKit/ReactiveKit.git", versions: Version(3, 1, 2)..<Version(4, 0, 0))
         .Package(url: "https://github.com/wokalski/Diff.swift.git", versions: Version(0, 4, 1)..<Version(1, 0, 0))
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "Bond",
     dependencies: [
-        .Package(url: "https://github.com/ReactiveKit/ReactiveKit.git", versions: Version(3, 1, 2)..<Version(4, 0, 0))
+        .Package(url: "https://github.com/ReactiveKit/ReactiveKit.git", versions: Version(3, 2, 0)..<Version(4, 0, 0))
         .Package(url: "https://github.com/wokalski/Diff.swift.git", versions: Version(0, 4, 1)..<Version(1, 0, 0))
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,5 +4,6 @@ let package = Package(
     name: "Bond",
     dependencies: [
         .Package(url: "https://github.com/ReactiveKit/ReactiveKit.git", versions: Version(3, 0, 0, prereleaseIdentifiers: ["beta"])..<Version(4, 0, 0))
+        .Package(url: "https://github.com/wokalski/Diff.swift.git", versions: Version(0, 4, 1)..<Version(1, 0, 0))
     ]
 )

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Bond is built on top of ReactiveKit and bridges the gap between the reactive and
 Let's say you would like to act on a text change event of a `UITextField`. Well, you could setup 'target-action' mechanism between your object and go through all that target-action selector registration pain, or you could simply use Bond and do this:
 
 ```swift
-textField.reactive.text
-  .observeNext { text in
+textField.reactive.text.observeNext { text in
     print(text)
   }
 ```
@@ -26,15 +25,13 @@ textField.reactive.text
 Now, instead of printing what the user has typed, you can _bind_ it to a `UILabel`:
 
 ```swift
-textField.reactive.text
-  .bind(to: label.reactive.text)
+textField.reactive.text.bind(to: label.reactive.text)
 ```
 
 Because binding to a label text property is so common, you can even do:
 
 ```swift
-textField.reactive.text
-  .bind(to: label)
+textField.reactive.text.bind(to: label)
 ```
 
 That one line establishes a binding between text field's text property and label's text property. In effect, whenever user makes a change to the text field, that change will be automatically propagated to the label.

--- a/README.md
+++ b/README.md
@@ -224,12 +224,12 @@ then the image processing will be automatically cancelled when the image view ge
 
 Bond provides NSObject extensions that makes it easy to convert delegate pattern into signals.
 
-First make an extension on your type, UITableView in the following example, that provides a reactive delegate proxy:
+First make an extension on ReactiveExtensions (where `Base` is defined as your type - `UITableView` in the following example), that provides a reactive delegate proxy:
 
 ```swift
-extension UITableView {
-  public delegate: ProtocolProxy {
-    return protocolProxy(for: UITableViewDelegate.self, setter: NSSelectorFromString("setDelegate:"))
+extension ReactiveExtensions where Base: UITableView {
+  public var delegate: ProtocolProxy {
+    return base.protocolProxy(for: UITableViewDelegate.self, setter: NSSelectorFromString("setDelegate:"))
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ repositories.bind(to: collectionView) { array, indexPath, collectionView in
   let repository = array[indexPath.item]
 
   repository.name
-    .bindTo(cell.nameLabel)
+    .bind(to: cell.nameLabel)
     .dispose(in: cell.onReuseBag)
 
   repository.photo
-    .bindTo(cell.avatarImageView)
+    .bind(to: cell.avatarImageView)
     .dispose(in: cell.onReuseBag)
 
   return cell

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Let's say you would like to act on a text change event of a `UITextField`. Well,
 
 ```swift
 textField.reactive.text.observeNext { text in
-    print(text)
-  }
+  print(text)
+}
 ```
 
 Now, instead of printing what the user has typed, you can _bind_ it to a `UILabel`:

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The producing side of bindings are signals that are defined in ReactiveKit frame
 The consuming side of bindings is represented by the `Bond` type. It's a simple struct that performs an action on a given target whenever the bound signal fires an event.
 
 ```swift
-public struct Bond<Target: Deallocatable, Element>: BindableProtocol {
+public struct Bond<Element>: BindableProtocol {
   public init(target: Target, setter: @escaping (Target, Element) -> Void)
 }
 ```
@@ -189,7 +189,7 @@ The only requirement is that the target must be "deallocatable", in other words 
 
 ```swift
 public protocol Deallocatable: class {
-  var bnd_deallocated: Signal<Void, NoError> { get }
+  deallocated: Signal<Void, NoError> { get }
 }
 ```
 
@@ -197,8 +197,8 @@ All NSObject subclasses conform to that protocol out of the box. Let's see how w
 
 ```swift
 extension UILabel {
-  var myTextBond: Bond<UILabel, String?> {
-    return Bond(target: self) { label, text in
+  var myTextBond: Bond<String?> {
+    return bond { label, text in
       label.text = text
     }
   }
@@ -233,7 +233,7 @@ First make an extension on your type, UITableView in the following example, that
 
 ```swift
 extension UITableView {
-  public var bnd_delegate: ProtocolProxy {
+  public delegate: ProtocolProxy {
     return protocolProxy(for: UITableViewDelegate.self, setter: NSSelectorFromString("setDelegate:"))
   }
 }
@@ -330,7 +330,7 @@ public enum DataSourceEventKind {
 If you have a signal that emits an array of elements, you can transform that signal into a signal that emits data source events using the operator `mapToDataSourceEvent` and bind it to a table view.
 
 ```swift
-let places = Signal1.just(["London", "Berlin", "Copenhagen"])
+let places = SafeSignal.just(["London", "Berlin", "Copenhagen"])
 
 places.mapToDataSourceEvent().bind(to: tableView) { places, indexPath, tableView in
   let cell = tableView.dequeueCell(withIdentifier: "Cell", for: indexPath) as! PlaceCell

--- a/README.md
+++ b/README.md
@@ -220,6 +220,36 @@ blurredImage().bind(to: imageView)
 
 then the image processing will be automatically cancelled when the image view gets deallocated. Isn't that cool!
 
+### Inline Bindings
+
+Most of the time you should be able to replace an observation with a binding. Consider the following example. Say we have a signal of users
+
+```swift
+let presentUserProfile: Signal<User, NoError> = ...
+```
+
+and we would like to present a profile screen when a user is sent on the signal. Usually we would do something like:
+
+```swift
+presentUserProfile.observeNext { [weak self] user in
+  let profileViewController = ProfileViewController(user: user)
+  self?.present(profileViewController, animated: true)
+}.dispose(in: reactive.bag)
+```
+
+But that's ugly! We have to be cautious not to create retain cycle and ensure that the disposable we get from the observation is handled.
+
+Thankfully Bond provides a better way. We can create inline binding instead of the observation. Just do the following
+
+```swift
+presentUserProfile.bind(to: self) { me, user in
+  let profileViewController = ProfileViewController(user: user)
+  me.present(profileViewController, animated: true)
+}
+```
+
+and stop worrying about cycles as bindings always reference the target weakly or about disposing because bindings take care of it automatically. Just bind a signal to the target responsible for performing side effects (in our example, to the object responsible for presenting a profile view controller). The closure you provide will be called whenever the signal emits an event with both the target and the sent element as arguments.
+
 ## Reactive Delegates
 
 Bond provides NSObject extensions that makes it easy to convert delegate pattern into signals.

--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@
 
 Bond is a Swift binding framework that takes binding concepts to a whole new level. It's simple, powerful, type-safe and multi-paradigm - just like Swift.
 
-Bond is also a framework that bridges the gap between the reactive and imperative paradigms. You can use it as a standalone framework to simplify your state changes with bindings and reactive data sources, but you can also use it with ReactiveKit to complement your reactive data flows with bindings and reactive delegates and data sources.
+Bond is built on top of ReactiveKit and bridges the gap between the reactive and imperative paradigms. You can use it as a standalone framework to simplify your state changes with bindings and reactive data sources, but you can also use it with ReactiveKit to complement your reactive data flows with bindings and reactive delegates and data sources.
 
-Bond 5 in built on top of ReactiveKit framework. There is no special configuration, it just works!
-
-**Note: This README describes Bond v5. For changes check out the [migration section](#migration)!**
+**Note: This document describes Bond v6. For changes check out the [migration section](#migration)!**
 
 
 ## What can it do?
@@ -19,7 +17,7 @@ Bond 5 in built on top of ReactiveKit framework. There is no special configurati
 Let's say you would like to act on a text change event of a `UITextField`. Well, you could setup 'target-action' mechanism between your object and go through all that target-action selector registration pain, or you could simply use Bond and do this:
 
 ```swift
-textField.bnd_text
+textField.reactive.text
   .observeNext { text in
     print(text)
   }
@@ -28,14 +26,14 @@ textField.bnd_text
 Now, instead of printing what the user has typed, you can _bind_ it to a `UILabel`:
 
 ```swift
-textField.bnd_text
-  .bind(to: label.bnd_text)
+textField.reactive.text
+  .bind(to: label.reactive.text)
 ```
 
 Because binding to a label text property is so common, you can even do:
 
 ```swift
-textField.bnd_text
+textField.reactive.text
   .bind(to: label)
 ```
 
@@ -44,19 +42,19 @@ That one line establishes a binding between text field's text property and label
 More often than not, direct binding is not enough. Usually you need to transform input is some way, like prepending a greeting to a name. As Bond is backed by ReactiveKit it has full confidence in functional paradigm.
 
 ```swift
-textField.bnd_text
+textField.reactive.text
   .map { "Hi " + $0 }
   .bind(to: label)
 ```
 
 Whenever a change occurs in the text field, new value will be transformed by the closure and propagated to the label.
 
-Notice how we've used `bnd_text` property of the UITextField. It's an observable representation of the `text` property provided by Bond framework. There are many other extensions like that one for various UIKit components. Just start typing _.bnd_ on any UIKit object and you'll get the list of available extensions.
+Notice how we've used `reactive.text` property of the UITextField. It's an observable representation of the `text` property provided by Bond framework. There are many other extensions like that one for various UIKit components. They are all placed within `.reactive` proxy. Just start typing `.reactive.` any UIKit object and you'll get the list of available extensions.
 
 For example, to observe button events do:
 
 ```swift
-button.bnd_controlEvents(.touchUpInside)
+button.reactive.controlEvents(.touchUpInside)
   .observeNext { e in
     print("Button tapped.")
   }
@@ -65,19 +63,19 @@ button.bnd_controlEvents(.touchUpInside)
 Handling `touchUpInside` event is used so frequently that Bond comes with the extension just for that event:
 
 ```swift
-button.bnd_tap
+button.reactive.tap
   .observe {
     print("Button tapped.")
   }  
 ```
 
-You can use any ReactiveKit operator to transform or combine signals. Following snippet depicts how values of two text fields can be reduced to a boolean value and applied to button's enabled property.
+You can use any ReactiveKit operators to transform or combine signals. Following snippet depicts how values of two text fields can be reduced to a boolean value and applied to button's enabled property.
 
 ```swift
-combineLatest(emailField.bnd_text, passField.bnd_text) { email, pass in
+combineLatest(emailField.reactive.text, passField.reactive.text) { email, pass in
     return email.length > 0 && pass.length > 0
   }
-  .bind(to: button.bnd_enabled)
+  .bind(to: button.reactive.enabled)
 ```
 
 Whenever user types something into any of these text fields, expression will be evaluated and button state updated.
@@ -96,17 +94,17 @@ Bond also supports two way bindings. Here is an example of how you could keep us
 
 ```swift
 viewModel.username
-  .bidirectionalBind(to: usernameTextField.bnd_text)
+  .bidirectionalBind(to: usernameTextField.reactive.text)
 ```
 
 Bond is also great for observing various different events and asynchronous tasks. For example, you could observe a notification just like this:
 
 ```swift
-NotificationCenter.default.bnd_notification("MyNotification")
+NotificationCenter.default.reactive.notification("MyNotification")
   .observeNext { notification in
     print("Got \(notification)")
   }
-  .disposeIn(bnd_bag)
+  .dispose(in: reactive.bag)
 ```
 
 Let me give you one last example. Say you have an array of repositories you would like to display in a collection view. For each repository you have a name and its owner's profile photo. Of course, photo is not immediately available as it has to be downloaded, but once you get it, you want it to appear in collection view's cell. Additionally, when user does 'pull down to refresh' and your array gets new repositories, you want those in collection view too.
@@ -120,11 +118,11 @@ repositories.bind(to: collectionView) { array, indexPath, collectionView in
 
   repository.name
     .bindTo(cell.nameLabel)
-    .disposeIn(cell.onReuseBag)
+    .dispose(in: cell.onReuseBag)
 
   repository.photo
     .bindTo(cell.avatarImageView)
-    .disposeIn(cell.onReuseBag)
+    .dispose(in: cell.onReuseBag)
 
   return cell
 }
@@ -173,7 +171,7 @@ name.bind(to: nameLabel)
 
 ## Bindings
 
-Binding is a connection between a Signal/Observable that produces events and a Bond that observers events and performs certain action (e.g. updates UI).
+Binding is a connection between a Signal/Observable that produces events and a Bond that observers events and performs certain actions (e.g. updates UI).
 
 The producing side of bindings are signals that are defined in ReactiveKit framework on top of which Bond is built. To learn more about signals, consult [ReactiveKit documentation](https://github.com/ReactiveKit/ReactiveKit).
 
@@ -181,7 +179,7 @@ The consuming side of bindings is represented by the `Bond` type. It's a simple 
 
 ```swift
 public struct Bond<Element>: BindableProtocol {
-  public init(target: Target, setter: @escaping (Target, Element) -> Void)
+  public init<Target: Deallocatable>(target: Target, setter: @escaping (Target, Element) -> Void)
 }
 ```
 
@@ -193,10 +191,10 @@ public protocol Deallocatable: class {
 }
 ```
 
-All NSObject subclasses conform to that protocol out of the box. Let's see how we could implement a Bond for text property of a label.
+All NSObject subclasses conform to that protocol out of the box. Let's see how we could implement a Bond for text property of a label. It's recommended to implement reactive extensions on `ReactiveExtensions` proxy protocol. That way you encapsulate extensions within the `.reactive` property.
 
 ```swift
-extension UILabel {
+extension ReactiveExtensions where Base: UILabel {
   var myTextBond: Bond<String?> {
     return bond { label, text in
       label.text = text
@@ -209,7 +207,7 @@ That's it! To bind any string signal, just use `bind(to:)` method on that bond.
 
 ```swift
 let name: Signal<String, NoError> = ...
-name.bind(to: nameLabel.myTextBond)
+name.bind(to: nameLabel.reactive.myTextBond)
 ```
 
 > Bonds will automatically ensure that the target object is updated on the main thread (queue). That means that the signal can generate events on a background thread without you worrying how the UI will be updated - it will always happen on the main thread.
@@ -239,14 +237,14 @@ extension UITableView {
 }
 ```
 
-> Note: `bnd_delegate` is already provided by Bond. This is an example of the implementation.
+> Note: `reactive.delegate` is already provided by Bond. This is an example of the implementation.
 
 You can then convert methods of that protocol into signals:
 
 ```swift
 extension UITableView {
   var selectedRow: Signal<Int, NoError> {
-    return bnd_delegate.signal(for: #selector(UITableViewDelegate.tableView(_:didSelectRowAtIndexPath:))) { (subject: PublishSubject<Int, NoError>, _: UITableView, indexPath: NSIndexPath) in 
+    return reactive.delegate.signal(for: #selector(UITableViewDelegate.tableView(_:didSelectRowAtIndexPath:))) { (subject: PublishSubject<Int, NoError>, _: UITableView, indexPath: NSIndexPath) in 
       subject.next(indexPath.row)
     }
   }
@@ -260,17 +258,17 @@ Now you can do:
 ```swift
 tableView.selectedRow.observeNext { row in
   print("Tapped row at index \(row).")
-}.disposeIn(bnd_bag)
+}.dispose(in: reactive.bag)
 ```
 
-**Note:** Protocol proxy takes up delegate slot of the object so if you also need to implement delegate methods manually, don't set `tableView.delegate = x`, rather set `tableView.bnd_delegate.forwardTo = x`.
+**Note:** Protocol proxy takes up delegate slot of the object so if you also need to implement delegate methods manually, don't set `tableView.delegate = x`, rather set `tableView.reactive.delegate.forwardTo = x`.
 
 Protocol methods that return values are usually used to query data. Such methods can be set up to be fed from a property type. For example:
 
 ```swift
 let numberOfItems = Property(12)
 
-tableView.bnd_dataSource.feed(
+tableView.reactive.dataSource.feed(
   property: numberOfItems,
   to: #selector(UITableViewDataSource.tableView(_:numberOfRowsInSection:)),
   map: { (value: Int, _: UITableView, _: Int) -> Int in value }
@@ -288,7 +286,7 @@ Note that in the mapping closures of both `signal(for:)` and `feed` methods you 
 
 Bond provides a way to make reactive data sources and allows such sources to be easily bound to table or collection views.
 
-Any Signal that emits elements of the following type can be bound to a table or collection view
+Any signal that emits elements of the following type can be bound to a table or collection view
 
 ```swift
 public struct DataSourceEvent<DataSource: DataSourceProtocol>: DataSourceEventProtocol {
@@ -327,12 +325,12 @@ public enum DataSourceEventKind {
 }
 ```
 
-If you have a signal that emits an array of elements, you can transform that signal into a signal that emits data source events using the operator `mapToDataSourceEvent` and bind it to a table view.
+If you have a signal that emits an array of elements you can bind it to a table view.
 
 ```swift
 let places = SafeSignal.just(["London", "Berlin", "Copenhagen"])
 
-places.mapToDataSourceEvent().bind(to: tableView) { places, indexPath, tableView in
+places.bind(to: tableView) { places, indexPath, tableView in
   let cell = tableView.dequeueCell(withIdentifier: "Cell", for: indexPath) as! PlaceCell
   cell.place = places[indexPath.row]
   return cell
@@ -522,19 +520,26 @@ There are many other methods. Just look at the code reference or source.
 ### Carthage
 
 1. Add the following to your *Cartfile*:
-  <br> `github "ReactiveKit/Bond" ~> 5.3`
+  <br> `github "ReactiveKit/Bond" ~> 6.0`
 2. Run `carthage update`
 3. Add the framework as described in [Carthage Readme](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application)
 
 ### CocoaPods
 
 1. Add the following to your *Podfile*:
-  <br> `pod 'Bond', '~> 5.3'`
+  <br> `pod 'Bond', '~> 6.0'`
 2. Run `pod install`.
 
 ## <a name="migration"></a>Migration
 
-### Migration from v4.x to v5.0
+### Migration from v5.x to v6.x
+
+* Extensions are moved into `reactive` proxy. Replace occurrences of `bnd_` with `reactive.`. For example `label.bnd_text` becomes `label.reactive.text`. The simplest way is to do _Search and Replace_ in Xcode across the project.
+* `Bond<Target, Element>` becomes `Bond<Element>`.
+* `DynamicSubject<Target, Element>` becomes `DynamicSubject<Element>`.
+* `disposeIn()` is deprecated in favour of `dispose(in:)`.
+
+### Migration from v4.x to v5.x
 
 There are some big changes in Bond v5! Bond is now backed by ReactiveKit framework. All reactive types have been moved down to ReactiveKit. Bond builds its infrastructure on top of ReactiveKit types, primarily on top of `Signal` that serves the purpose of `EventProducer`.
 
@@ -558,7 +563,7 @@ What that means for you? Well, nothing has changed conceptually so your migratio
 
 The MIT License (MIT)
 
-Copyright (c) 2015-2016 Srdan Rasic (@srdanrasic)
+Copyright (c) 2015-2017 Srdan Rasic (@srdanrasic)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -231,13 +231,13 @@ let presentUserProfile: Signal<User, NoError> = ...
 and we would like to present a profile screen when a user is sent on the signal. Usually we would do something like:
 
 ```swift
-presentUserProfile.observeNext { [weak self] user in
+presentUserProfile.observeOn(.main).observeNext { [weak self] user in
   let profileViewController = ProfileViewController(user: user)
   self?.present(profileViewController, animated: true)
 }.dispose(in: reactive.bag)
 ```
 
-But that's ugly! We have to be cautious not to create retain cycle and ensure that the disposable we get from the observation is handled.
+But that's ugly! We have to dispatch everything to the main queue, be cautious not to create a retain cycle and ensure that the disposable we get from the observation is handled.
 
 Thankfully Bond provides a better way. We can create inline binding instead of the observation. Just do the following
 
@@ -248,7 +248,7 @@ presentUserProfile.bind(to: self) { me, user in
 }
 ```
 
-and stop worrying about cycles as bindings always reference the target weakly or about disposing because bindings take care of it automatically. Just bind a signal to the target responsible for performing side effects (in our example, to the object responsible for presenting a profile view controller). The closure you provide will be called whenever the signal emits an event with both the target and the sent element as arguments.
+and stop worrying about threading, retain cycles and disposing  because bindings take care of all that automatically. Just bind a signal to the target responsible for performing side effects (in our example, to the object responsible for presenting a profile view controller). The closure you provide will be called whenever the signal emits an event with both the target and the sent element as arguments.
 
 ## Reactive Delegates
 

--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ There are many other methods. Just look at the code reference or source.
 ### CocoaPods
 
 1. Add the following to your *Podfile*:
-  <br> `pod 'Bond', '~> 6.0'`
+  <br> `pod 'Bond', '~> 6.0-beta'`
 2. Run `pod install`.
 
 ## <a name="migration"></a>Migration

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The only requirement is that the target must be "deallocatable", in other words 
 
 ```swift
 public protocol Deallocatable: class {
-  deallocated: Signal<Void, NoError> { get }
+  var deallocated: Signal<Void, NoError> { get }
 }
 ```
 

--- a/Sources/AppKit/NSAppearanceCustomization.swift
+++ b/Sources/AppKit/NSAppearanceCustomization.swift
@@ -22,12 +22,12 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import AppKit
+import ReactiveKit
 
-public extension NSAppearanceCustomization where Self: NSObject {
+public extension ReactiveExtensions where Base: NSObject, Base: NSAppearanceCustomization {
 
-  public var bnd_appearance: Bond<Self, NSAppearance?> {
-    return Bond(target: self) { $0.appearance = $1 }
+  public var appearance: Bond<NSAppearance?> {
+    return bond { $0.appearance = $1 }
   }
 }

--- a/Sources/AppKit/NSButton.swift
+++ b/Sources/AppKit/NSButton.swift
@@ -25,17 +25,17 @@
 import AppKit
 import ReactiveKit
 
-public extension NSButton {
+public extension ReactiveExtensions where Base: NSButton {
 
-  public var bnd_title: Bond<NSButton, String> {
-    return Bond(target: self) { $0.title = $1 }
+  public var title: Bond<String> {
+    return bond { $0.title = $1 }
   }
 
-  public var bnd_alternateTitle: Bond<NSButton, String> {
-    return Bond(target: self) { $0.alternateTitle = $1 }
+  public var alternateTitle: Bond<String> {
+    return bond { $0.alternateTitle = $1 }
   }
 
-  public var bnd_state: Bond<NSButton, Int> {
-    return Bond(target: self) { $0.state = $1 }
+  public var state: Bond<Int> {
+    return bond { $0.state = $1 }
   }
 }

--- a/Sources/AppKit/NSColorWell.swift
+++ b/Sources/AppKit/NSColorWell.swift
@@ -22,12 +22,12 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import AppKit
+import ReactiveKit
 
-public extension NSColorWell {
+public extension ReactiveExtensions where Base: NSColorWell {
 
-  public var bnd_color: Bond<NSColorWell, NSColor> {
-    return Bond(target: self) { $0.color = $1 }
+  public var color: Bond<NSColor> {
+    return bond { $0.color = $1 }
   }
 }

--- a/Sources/AppKit/NSControl.swift
+++ b/Sources/AppKit/NSControl.swift
@@ -63,7 +63,7 @@ public extension ReactiveExtensions where Base: NSControl {
       return (controlHelper as! NSControl.BondHelper).subject.toSignal()
     } else {
       let controlHelper = NSControl.BondHelper(control: base)
-      objc_setAssociatedObject(self, &NSControl.AssociatedKeys.ControlHelperKey, controlHelper, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+      objc_setAssociatedObject(base, &NSControl.AssociatedKeys.ControlHelperKey, controlHelper, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
       return controlHelper.subject.toSignal()
     }
   }

--- a/Sources/AppKit/NSImageView.swift
+++ b/Sources/AppKit/NSImageView.swift
@@ -22,19 +22,19 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import AppKit
+import ReactiveKit
 
-extension NSImageView {
+public extension ReactiveExtensions where Base: NSImageView {
 
-  public var bnd_image: Bond<NSImageView, NSImage?> {
-    return Bond(target: self) { $0.image = $1 }
+  public var image: Bond<NSImage?> {
+    return bond { $0.image = $1 }
   }
 }
 
 extension NSImageView: BindableProtocol {
 
   public func bind(signal: Signal<NSImage?, NoError>) -> Disposable {
-    return bnd_image.bind(signal: signal)
+    return reactive.image.bind(signal: signal)
   }
 }

--- a/Sources/AppKit/NSMenuItem.swift
+++ b/Sources/AppKit/NSMenuItem.swift
@@ -22,16 +22,16 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import AppKit
+import ReactiveKit
 
-public extension NSMenuItem {
+public extension ReactiveExtensions where Base: NSMenuItem {
 
-  public var bnd_state: Bond<NSMenuItem, Int> {
-    return Bond(target: self) { $0.state = $1 }
+  public var state: Bond<Int> {
+    return bond { $0.state = $1 }
   }
 
-  public var bnd_isEnabled: Bond<NSMenuItem, Bool> {
-    return Bond(target: self) { $0.isEnabled = $1 }
+  public var isEnabled: Bond<Bool> {
+    return bond { $0.isEnabled = $1 }
   }
 }

--- a/Sources/AppKit/NSPopUpButton.swift
+++ b/Sources/AppKit/NSPopUpButton.swift
@@ -1,0 +1,68 @@
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2016 Tony Arnold (@tonyarnold)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import AppKit
+import ReactiveKit
+
+public extension ReactiveExtensions where Base: NSPopUpButton {
+
+  public var selectedItem: DynamicSubject<NSMenuItem?> {
+    return dynamicSubject(
+      signal: keyPath(#keyPath(NSPopUpButton.selectedItem), ofType: Optional<NSMenuItem>.self).eraseType(),
+      get: { $0.selectedItem },
+      set: { $0.select($1) }
+    )
+  }
+
+  public var selectedItemAtIndex: DynamicSubject<Int?> {
+    return dynamicSubject(
+      signal: selectedItem.toSignal().eraseType(),
+      get: { $0.indexOfSelectedItem >= 0 ? $0.indexOfSelectedItem : nil },
+      set: { $0.selectItem(at: $1 ?? -1) }
+    )
+  }
+
+  public var selectedItemWithTitle: DynamicSubject<String?> {
+    return dynamicSubject(
+      signal: selectedItem.toSignal().eraseType(),
+      get: { $0.titleOfSelectedItem },
+      set: { $0.selectItem(withTitle: $1 ?? "") }
+    )
+  }
+
+  public var selectedItemWithTag: DynamicSubject<Int> {
+    return dynamicSubject(
+      signal: selectedItem.toSignal().eraseType(),
+      get: { $0.selectedItem?.tag ?? -1 },
+      set: { $0.selectItem(withTag: $1) }
+    )
+  }
+}
+
+extension NSPopUpButton: BindableProtocol {
+
+  public func bind(signal: Signal<NSMenuItem?, NoError>) -> Disposable {
+    return reactive.selectedItem.bind(signal: signal)
+  }
+}

--- a/Sources/AppKit/NSProgressIndicator.swift
+++ b/Sources/AppKit/NSProgressIndicator.swift
@@ -22,19 +22,19 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import AppKit
+import ReactiveKit
 
-extension NSProgressIndicator {
+public extension ReactiveExtensions where Base: NSProgressIndicator {
 
-  public var bnd_doubleValue: Bond<NSProgressIndicator, Double> {
-    return Bond(target: self) { $0.doubleValue = $1 }
+  public var doubleValue: Bond<Double> {
+    return bond { $0.doubleValue = $1 }
   }
 }
 
 extension NSProgressIndicator: BindableProtocol {
 
   public func bind(signal: Signal<Double, NoError>) -> Disposable {
-    return bnd_doubleValue.bind(signal: signal)
+    return reactive.doubleValue.bind(signal: signal)
   }
 }

--- a/Sources/AppKit/NSSegmentedControl.swift
+++ b/Sources/AppKit/NSSegmentedControl.swift
@@ -22,23 +22,23 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import AppKit
+import ReactiveKit
 
-extension NSSegmentedControl {
+public extension ReactiveExtensions where Base: NSSegmentedControl {
 
-  public var bnd_segmentCount: Bond<NSSegmentedControl, Int> {
-    return Bond(target: self) { $0.segmentCount = $1 }
+  public var segmentCount: Bond<Int> {
+    return bond { $0.segmentCount = $1 }
   }
 
-  public var bnd_selectedSegment: Bond<NSSegmentedControl, Int> {
-    return Bond(target: self) { $0.selectedSegment = $1 }
+  public var selectedSegment: Bond<Int> {
+    return bond { $0.selectedSegment = $1 }
   }
 }
 
-extension NSSegmentedControl {
+extension NSSegmentedControl: BindableProtocol {
   
   public func bind(signal: Signal<Int, NoError>) -> Disposable {
-    return bnd_selectedSegment.bind(signal: signal)
+    return reactive.selectedSegment.bind(signal: signal)
   }
 }

--- a/Sources/AppKit/NSSlider.swift
+++ b/Sources/AppKit/NSSlider.swift
@@ -22,27 +22,27 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import AppKit
+import ReactiveKit
 
-extension NSSlider {
+public extension ReactiveExtensions where Base: NSSlider {
 
-  public var bnd_minValue: Bond<NSSlider, Double> {
-    return Bond(target: self) { $0.minValue = $1 }
+  public var minValue: Bond<Double> {
+    return bond { $0.minValue = $1 }
   }
 
-  public var bnd_maxValue: Bond<NSSlider, Double> {
-    return Bond(target: self) { $0.maxValue = $1 }
+  public var maxValue: Bond<Double> {
+    return bond { $0.maxValue = $1 }
   }
 
-  public var bnd_altIncrementValue: Bond<NSSlider, Double> {
-    return Bond(target: self) { $0.altIncrementValue = $1 }
+  public var altIncrementValue: Bond<Double> {
+    return bond { $0.altIncrementValue = $1 }
   }
 }
 
 extension NSSlider: BindableProtocol {
 
   public func bind(signal: Signal<Double, NoError>) -> Disposable {
-    return bnd_doubleValue.bind(signal: signal)
+    return reactive.doubleValue.bind(signal: signal)
   }
 }

--- a/Sources/AppKit/NSStatusBarButton.swift
+++ b/Sources/AppKit/NSStatusBarButton.swift
@@ -22,12 +22,12 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import AppKit
+import ReactiveKit
 
-public extension NSStatusBarButton {
+public extension ReactiveExtensions where Base: NSStatusBarButton {
 
-  public var bnd_appearsDisabled: Bond<NSStatusBarButton, Bool> {
-    return Bond(target: self) { $0.appearsDisabled = $1 }
+  public var appearsDisabled: Bond<Bool> {
+    return bond { $0.appearsDisabled = $1 }
   }
 }

--- a/Sources/AppKit/NSTableView.swift
+++ b/Sources/AppKit/NSTableView.swift
@@ -25,14 +25,14 @@ public extension SignalProtocol where Element: DataSourceEventProtocol, Error ==
   public typealias DataSource = Element.DataSource
 
   @discardableResult
-  public func bind(to tableView: NSTableView, animated: Bool = true, createCell: @escaping (DataSource, Int, NSTableView) -> NSView) -> Disposable {
+  public func bind(to tableView: NSTableView, animated: Bool = true, createCell: @escaping (DataSource, Int, NSTableView) -> NSView?) -> Disposable {
 
     let dataSource = Property<DataSource?>(nil)
 
     tableView.reactive.delegate.feed(
       property: dataSource,
       to: #selector(NSTableViewDelegate.tableView(_:viewFor:row:)),
-      map: { (dataSource: DataSource?, tableView: NSTableView, column: NSTableColumn, row: Int) -> NSView in
+      map: { (dataSource: DataSource?, tableView: NSTableView, column: NSTableColumn, row: Int) -> NSView? in
         return createCell(dataSource!, row, tableView)
     })
 

--- a/Sources/AppKit/NSTableView.swift
+++ b/Sources/AppKit/NSTableView.swift
@@ -9,14 +9,14 @@
 import AppKit
 import ReactiveKit
 
-public extension NSTableView {
+public extension ReactiveExtensions where Base: NSTableView {
 
-  public var rDelegate: ProtocolProxy {
-    return protocolProxy(for: NSTableViewDelegate.self, setter: NSSelectorFromString("setDelegate:"))
+  public var delegate: ProtocolProxy {
+    return base.protocolProxy(for: NSTableViewDelegate.self, setter: NSSelectorFromString("setDelegate:"))
   }
 
-  public var rDataSource: ProtocolProxy {
-    return protocolProxy(for: NSTableViewDataSource.self, setter: NSSelectorFromString("setDataSource:"))
+  public var dataSource: ProtocolProxy {
+    return base.protocolProxy(for: NSTableViewDataSource.self, setter: NSSelectorFromString("setDataSource:"))
   }
 }
 
@@ -29,14 +29,14 @@ public extension SignalProtocol where Element: DataSourceEventProtocol, Error ==
 
     let dataSource = Property<DataSource?>(nil)
 
-    tableView.rDelegate.feed(
+    tableView.reactive.delegate.feed(
       property: dataSource,
       to: #selector(NSTableViewDelegate.tableView(_:viewFor:row:)),
       map: { (dataSource: DataSource?, tableView: NSTableView, column: NSTableColumn, row: Int) -> NSView in
         return createCell(dataSource!, row, tableView)
     })
 
-    tableView.rDataSource.feed(
+    tableView.reactive.dataSource.feed(
       property: dataSource,
       to: #selector(NSTableViewDataSource.numberOfRows(in:)),
       map: { (dataSource: DataSource?, _: NSTableView) -> Int in dataSource?.numberOfItems(inSection: 0) ?? 0 }

--- a/Sources/AppKit/NSTextField.swift
+++ b/Sources/AppKit/NSTextField.swift
@@ -46,6 +46,66 @@ public extension ReactiveExtensions where Base: NSTextField {
   public var placeholderAttributedString: Bond<NSAttributedString?> {
     return bond { $0.placeholderAttributedString = $1 }
   }
+
+  public var editingString: DynamicSubject<String> {
+    return dynamicSubject(
+      signal: self.textDidChange.eraseType(),
+      get: { (textField: NSTextField) -> String in
+        return textField.formatter?.editingString(for: textField.stringValue) ?? textField.stringValue
+      },
+      set: { (textField: NSTextField, value: String) in
+        textField.stringValue = value
+      }
+    )
+  }
+
+  public var textDidChange: SafeSignal<NSTextField> {
+    return NotificationCenter.default
+      .reactive.notification(name: .NSControlTextDidChange, object: base)
+      .map { $0.object as? NSTextField }
+      .ignoreNil()
+  }
+
+  public var textDidBeginEditing: SafeSignal<NSTextField> {
+    return NotificationCenter.default
+      .reactive.notification(name: .NSControlTextDidBeginEditing, object: base)
+      .map { $0.object as? NSTextField }
+      .ignoreNil()
+  }
+
+  public var textDidEndEditing: SafeSignal<(NSTextField, Bool)> {
+    return NotificationCenter.default
+      .reactive.notification(name: .NSControlTextDidEndEditing, object: base)
+      .map { notification -> (NSTextField, Bool)? in
+        guard let textField = notification.object as? NSTextField else {
+          return nil
+        }
+
+        return (textField, Self.resignedFirstResponder(in: notification))
+      }
+      .ignoreNil()
+  }
+
+  /// Interrogates the passed notification for details of how the field ended editing, and if it resigned its first responder status as a result.
+  ///
+  /// - Parameter notification: Notification of type `NSControlTextDidEndEditing`
+  /// - Returns: true if the text field resigned first responder, false if it did not
+  private static func resignedFirstResponder(in notification: Notification) -> Bool {
+    guard
+      notification.name == .NSControlTextDidEndEditing,
+      let textField = notification.object as? NSTextField,
+      let textMovement = notification.userInfo?["NSTextMovement"] as? Int
+    else {
+      return false
+    }
+
+    let returnKeyPressed = (textMovement == NSReturnTextMovement)
+    let tabKeyPressed = (textMovement == NSTabTextMovement || textMovement == NSBacktabTextMovement)
+    let tabbedIntoTextField = tabKeyPressed && textField.nextKeyView == textField
+    let tabbedOutOfTextField = tabKeyPressed && textField.nextKeyView == nil
+
+    return (returnKeyPressed || tabbedIntoTextField || tabbedOutOfTextField)
+  }
 }
 
 extension NSTextField: BindableProtocol {

--- a/Sources/AppKit/NSTextField.swift
+++ b/Sources/AppKit/NSTextField.swift
@@ -22,35 +22,35 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import AppKit
+import ReactiveKit
 
-extension NSTextField {
+public extension ReactiveExtensions where Base: NSTextField {
 
-  public var bnd_font: Bond<NSTextField, NSFont?> {
-    return Bond(target: self) { $0.font = $1 }
+  public var font: Bond<NSFont?> {
+    return bond { $0.font = $1 }
   }
 
-  public var bnd_textColor: Bond<NSTextField, NSColor?> {
-    return Bond(target: self) { $0.textColor = $1 }
+  public var textColor: Bond<NSColor?> {
+    return bond { $0.textColor = $1 }
   }
 
-  public var bnd_backgroundColor: Bond<NSTextField, NSColor?> {
-    return Bond(target: self) { $0.backgroundColor = $1 }
+  public var backgroundColor: Bond<NSColor?> {
+    return bond { $0.backgroundColor = $1 }
   }
 
-  public var bnd_placeholderString: Bond<NSTextField, String?> {
-    return Bond(target: self) { $0.placeholderString = $1 }
+  public var placeholderString: Bond<String?> {
+    return bond { $0.placeholderString = $1 }
   }
 
-  public var bnd_placeholderAttributedString: Bond<NSTextField, NSAttributedString?> {
-    return Bond(target: self) { $0.placeholderAttributedString = $1 }
+  public var placeholderAttributedString: Bond<NSAttributedString?> {
+    return bond { $0.placeholderAttributedString = $1 }
   }
 }
 
 extension NSTextField: BindableProtocol {
 
   public func bind(signal: Signal<String, NoError>) -> Disposable {
-    return bnd_stringValue.bind(signal: signal)
+    return reactive.stringValue.bind(signal: signal)
   }
 }

--- a/Sources/AppKit/NSTextView.swift
+++ b/Sources/AppKit/NSTextView.swift
@@ -27,10 +27,9 @@ import ReactiveKit
 
 public extension ReactiveExtensions where Base: NSTextView {
 
-  public var string: DynamicSubject<NSTextView, String?> {
+  public var string: DynamicSubject<String?> {
     let notificationName = NSNotification.Name.NSTextDidChange
-    return DynamicSubject(
-      target: base,
+    return dynamicSubject(
       signal: NotificationCenter.default.reactive.notification(name: notificationName, object: base).eraseType(),
       get: { $0.string },
       set: { $0.string = $1 }

--- a/Sources/AppKit/NSTextView.swift
+++ b/Sources/AppKit/NSTextView.swift
@@ -22,16 +22,16 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import AppKit
+import ReactiveKit
 
-public extension NSTextView {
+public extension ReactiveExtensions where Base: NSTextView {
 
-  public var bnd_string: DynamicSubject<NSTextView, String?> {
+  public var string: DynamicSubject<NSTextView, String?> {
     let notificationName = NSNotification.Name.NSTextDidChange
     return DynamicSubject(
-      target: self,
-      signal: NotificationCenter.default.bnd_notification(name: notificationName, object: self).eraseType(),
+      target: base,
+      signal: NotificationCenter.default.reactive.notification(name: notificationName, object: base).eraseType(),
       get: { $0.string },
       set: { $0.string = $1 }
     )

--- a/Sources/AppKit/NSView.swift
+++ b/Sources/AppKit/NSView.swift
@@ -22,16 +22,16 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import AppKit
+import ReactiveKit
 
-extension NSView {
+public extension ReactiveExtensions where Base: NSView {
 
-  public var bnd_alphaValue: Bond<NSView, CGFloat> {
-    return Bond(target: self) { $0.alphaValue = $1 }
+  public var alphaValue: Bond<CGFloat> {
+    return bond { $0.alphaValue = $1 }
   }
 
-  public var bnd_isHidden: Bond<NSView, Bool> {
-    return Bond(target: self) { $0.isHidden = $1 }
+  public var isHidden: Bond<Bool> {
+    return bond { $0.isHidden = $1 }
   }
 }

--- a/Sources/AppKit/NSView.swift
+++ b/Sources/AppKit/NSView.swift
@@ -34,4 +34,8 @@ public extension ReactiveExtensions where Base: NSView {
   public var isHidden: Bond<Bool> {
     return bond { $0.isHidden = $1 }
   }
+
+  public var toolTip: Bond<String?> {
+    return bond { $0.toolTip = $1 }
+  }
 }

--- a/Sources/Bond.swift
+++ b/Sources/Bond.swift
@@ -51,7 +51,20 @@ public struct Bond<Element>: BindableProtocol {
 
 extension ReactiveExtensions where Base: Deallocatable {
 
+  /// Creates a bond on the receiver.
   public func bond<Element>(setter: @escaping (Base, Element) -> Void) -> Bond<Element> {
     return Bond(target: base, setter: setter)
+  }
+}
+
+
+extension SignalProtocol where Error == NoError {
+
+  /// Bind signal to the target using the given setter closure.
+  /// Closure is called whenever the signal emits an event.
+  /// Binding will live until either signal completes or target is deallocated.
+  @discardableResult
+  public func bind<Target: Deallocatable>(to target: Target, setter: @escaping (Target, Element) -> Void) -> Disposable {
+    return bind(to: Bond(target: target, setter: setter))
   }
 }

--- a/Sources/Collections/Observable2DArray.swift
+++ b/Sources/Collections/Observable2DArray.swift
@@ -447,9 +447,11 @@ extension MutableObservable2DArray where Item: Equatable {
 
 extension MutableObservable2DArray where Item: Equatable, SectionMetadata: Equatable {
   
-  // Replace the entire 2DArray performing diff [if given] on all sections and section's items
-  // resulting in a series of ordered events (deleteSection, deleteItems, insertSections, insertItems) that migrate the old 2DArray to the new 2DArray
-  // Note that both Item and SectionMetadata should be Equatable
+  /// Replace the entire 2DArray performing nested diff (if preformDiff is true) on all
+  /// sections and section's items resulting in a series of ordered events (deleteSection,
+  /// deleteItems, insertSections, insertItems, moveSection, moveItem) that migrate the old
+  /// 2DArray to the new 2DArray
+  /// Note that both Item and SectionMetadata should be Equatable
   public func replace2D(with list: Observable2DArray<SectionMetadata, Item>, performDiff: Bool) {
     
     if performDiff {

--- a/Sources/Collections/Observable2DArray.swift
+++ b/Sources/Collections/Observable2DArray.swift
@@ -52,6 +52,16 @@ public protocol Observable2DArrayEventProtocol {
 public struct Observable2DArrayEvent<SectionMetadata, Item> {
   public let change: Observable2DArrayChange
   public let source: Observable2DArray<SectionMetadata, Item>
+
+  public init(change: Observable2DArrayChange, source: Observable2DArray<SectionMetadata, Item>) {
+    self.change = change
+    self.source = source
+  }
+
+  public init(change: Observable2DArrayChange, source: [Observable2DArraySection<SectionMetadata, Item>]) {
+    self.change = change
+    self.source = Observable2DArray(source)
+  }
 }
 
 /// Represents a section in 2D array.

--- a/Sources/Collections/Observable2DArray.swift
+++ b/Sources/Collections/Observable2DArray.swift
@@ -138,7 +138,7 @@ public class Observable2DArray<SectionMetadata, Item>: Collection, SignalProtoco
 
 extension Observable2DArray: Deallocatable {
 
-  public var bnd_deallocated: Signal<Void, NoError> {
+  public var deallocated: Signal<Void, NoError> {
     return subject.disposeBag.deallocated
   }
 }

--- a/Sources/Collections/Observable2DArray.swift
+++ b/Sources/Collections/Observable2DArray.swift
@@ -27,17 +27,17 @@ import Diff
 
 public enum Observable2DArrayChange {
   case reset
-
+  
   case insertItems([IndexPath])
   case deleteItems([IndexPath])
   case updateItems([IndexPath])
   case moveItem(IndexPath, IndexPath)
-
+  
   case insertSections(IndexSet)
   case deleteSections(IndexSet)
   case updateSections(IndexSet)
   case moveSection(Int, Int)
-
+  
   case beginBatchEditing
   case endBatchEditing
 }
@@ -56,39 +56,67 @@ public struct Observable2DArrayEvent<SectionMetadata, Item> {
 
 /// Represents a section in 2D array.
 /// Section contains its metadata (e.g. header string) and items.
-public struct Observable2DArraySection<Metadata, Item> {
-
+public struct Observable2DArraySection<Metadata, Item>: Collection {
+  
   public var metadata: Metadata
   public var items: [Item]
-
+  
   public init(metadata: Metadata, items: [Item] = []) {
     self.metadata = metadata
     self.items = items
   }
+  
+  
+  public var startIndex: Int {
+    return items.startIndex
+  }
+  
+  
+  public var endIndex: Int {
+    return items.endIndex
+  }
+  
+  public var count: Int {
+    return items.count
+  }
+  
+  public var isEmpty: Bool {
+    return items.isEmpty
+  }
+  
+  public func index(after i: Int) -> Int {
+    return items.index(after: i)
+  }
+  public subscript(index: Int) -> Item {
+    get {
+      return items[index]
+    }
+  }
+  
 }
 
 public class Observable2DArray<SectionMetadata, Item>: Collection, SignalProtocol {
-
+  
   public fileprivate(set) var sections: [Observable2DArraySection<SectionMetadata, Item>]
   fileprivate let subject = PublishSubject<Observable2DArrayEvent<SectionMetadata, Item>, NoError>()
   fileprivate let lock = NSRecursiveLock(name: "com.reactivekit.bond.observable2darray")
-
+  
   public init(_ sections:  [Observable2DArraySection<SectionMetadata, Item>] = []) {
     self.sections = sections
   }
-
+  
   public var numberOfSections: Int {
     return sections.count
   }
-
+  
   public func numberOfItems(inSection section: Int) -> Int {
     return sections[section].items.count
   }
-
+  
   public var startIndex: IndexPath {
     return IndexPath(item: 0, section: 0)
   }
-
+  
   public var endIndex: IndexPath {
     if numberOfSections == 0 {
       return IndexPath(item: 0, section: 0)
@@ -97,7 +125,7 @@ public class Observable2DArray<SectionMetadata, Item>: Collection, SignalProtoco
       return IndexPath(item: lastSection.items.count, section: numberOfSections - 1)
     }
   }
-
+  
   public func index(after i: IndexPath) -> IndexPath {
     if i.section < sections.count {
       let section = sections[i.section]
@@ -114,27 +142,27 @@ public class Observable2DArray<SectionMetadata, Item>: Collection, SignalProtoco
       return endIndex
     }
   }
-
+  
   public var isEmpty: Bool {
     return sections.reduce(true) { $0 && $1.items.isEmpty }
   }
-
+  
   public var count: Int {
     return sections.reduce(0) { $0 + $1.items.count }
   }
-
+  
   public subscript(index: IndexPath) -> Item {
     get {
       return sections[index.section].items[index.item]
     }
   }
-
+  
   public subscript(index: Int) -> Observable2DArraySection<SectionMetadata, Item> {
     get {
       return sections[index]
     }
   }
-
+  
   public func observe(with observer: @escaping (Event<Observable2DArrayEvent<SectionMetadata, Item>, NoError>) -> Void) -> Disposable {
     observer(.next(Observable2DArrayEvent(change: .reset, source: self)))
     return subject.observe(with: observer)
@@ -142,14 +170,14 @@ public class Observable2DArray<SectionMetadata, Item>: Collection, SignalProtoco
 }
 
 extension Observable2DArray: Deallocatable {
-
+  
   public var deallocated: Signal<Void, NoError> {
     return subject.disposeBag.deallocated
   }
 }
 
 public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<SectionMetadata, Item> {
-
+  
   /// Append new section at the end of the 2D array.
   public func appendSection(_ section: Observable2DArraySection<SectionMetadata, Item>) {
     lock.lock(); defer { lock.unlock() }
@@ -166,7 +194,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
       subject.next(Observable2DArrayEvent(change: .insertSections([sectionIndex]), source: self))
     }
   }
-
+  
   /// Append `item` to the section `section` of the array.
   public func appendItem(_ item: Item, toSection section: Int) {
     lock.lock(); defer { lock.unlock() }
@@ -174,7 +202,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     let indexPath = IndexPath(item: sections[section].items.count - 1, section: section)
     subject.next(Observable2DArrayEvent(change: .insertItems([indexPath]), source: self))
   }
-
+  
   /// Insert section at `index` with `items`.
   public func insert(section: Observable2DArraySection<SectionMetadata, Item>, at index: Int)  {
     lock.lock(); defer { lock.unlock() }
@@ -190,14 +218,14 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
       subject.next(Observable2DArrayEvent(change: .insertSections([index]), source: self))
     }
   }
-
+  
   /// Insert `item` at `indexPath`.
   public func insert(item: Item, at indexPath: IndexPath)  {
     lock.lock(); defer { lock.unlock() }
     sections[indexPath.section].items.insert(item, at: indexPath.item)
     subject.next(Observable2DArrayEvent(change: .insertItems([indexPath]), source: self))
   }
-
+  
   /// Insert `items` at index path `indexPath`.
   public func insert(contentsOf items: [Item], at indexPath: IndexPath) {
     lock.lock(); defer { lock.unlock() }
@@ -206,7 +234,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     let indexPaths = indices.map { IndexPath(item: $0, section: indexPath.section) }
     subject.next(Observable2DArrayEvent(change: .insertItems(indexPaths), source: self))
   }
-
+  
   /// Move the section at index `fromIndex` to index `toIndex`.
   public func moveSection(from fromIndex: Int, to toIndex: Int) {
     lock.lock(); defer { lock.unlock() }
@@ -214,7 +242,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     sections.insert(section, at: toIndex)
     subject.next(Observable2DArrayEvent(change: .moveSection(fromIndex, toIndex), source: self))
   }
-
+  
   /// Move the item at `fromIndexPath` to `toIndexPath`.
   public func moveItem(from fromIndexPath: IndexPath, to toIndexPath: IndexPath) {
     lock.lock(); defer { lock.unlock() }
@@ -222,7 +250,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     sections[toIndexPath.section].items.insert(item, at: toIndexPath.item)
     subject.next(Observable2DArrayEvent(change: .moveItem(fromIndexPath, toIndexPath), source: self))
   }
-
+  
   /// Remove and return the section at `index`.
   @discardableResult
   public func removeSection(at index: Int) -> Observable2DArraySection<SectionMetadata, Item> {
@@ -231,7 +259,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     subject.next(Observable2DArrayEvent(change: .deleteSections([index]), source: self))
     return element
   }
-
+  
   /// Remove and return the item at `indexPath`.
   @discardableResult
   public func removeItem(at indexPath: IndexPath) -> Item {
@@ -240,21 +268,21 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     subject.next(Observable2DArrayEvent(change: .deleteItems([indexPath]), source: self))
     return element
   }
-
+  
   /// Remove all items from the array. Keep empty sections.
   public func removeAllItems() {
     lock.lock(); defer { lock.unlock() }
     let indexPaths = sections.enumerated().reduce([]) { (indexPaths, section) -> [IndexPath] in
       indexPaths + section.element.items.indices.map { IndexPath(item: $0, section: section.offset) }
     }
-
+    
     for index in sections.indices {
       sections[index].items.removeAll()
     }
-
+    
     subject.next(Observable2DArrayEvent(change: .deleteItems(indexPaths), source: self))
   }
-
+  
   /// Remove all items and sections from the array.
   public func removeAllItemsAndSections() {
     lock.lock(); defer { lock.unlock() }
@@ -262,7 +290,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     sections.removeAll()
     subject.next(Observable2DArrayEvent(change: .deleteSections(IndexSet(integersIn: indices)), source: self))
   }
-
+  
   public override subscript(index: IndexPath) -> Item {
     get {
       return sections[index.section].items[index.item]
@@ -273,7 +301,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
       subject.next(Observable2DArrayEvent(change: .updateItems([index]), source: self))
     }
   }
-
+  
   /// Perform batched updates on the array.
   public func batchUpdate(_ update: (MutableObservable2DArray<SectionMetadata, Item>) -> Void) {
     lock.lock(); defer { lock.unlock() }
@@ -281,7 +309,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     update(self)
     subject.next(Observable2DArrayEvent(change: .endBatchEditing, source: self))
   }
-
+  
   /// Change the underlying value withouth notifying the observers.
   public func silentUpdate(_ update: (inout [Observable2DArraySection<SectionMetadata, Item>]) -> Void) {
     lock.lock(); defer { lock.unlock() }
@@ -290,7 +318,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
 }
 
 extension MutableObservable2DArray: BindableProtocol {
-
+  
   public func bind(signal: Signal<Observable2DArrayEvent<SectionMetadata, Item>, NoError>) -> Disposable {
     return signal
       .take(until: deallocated)
@@ -305,7 +333,7 @@ extension MutableObservable2DArray: BindableProtocol {
 // MARK: DataSourceProtocol conformation
 
 extension Observable2DArrayEvent: DataSourceEventProtocol {
-
+  
   public var kind: DataSourceEventKind {
     switch change {
     case .reset:
@@ -332,7 +360,7 @@ extension Observable2DArrayEvent: DataSourceEventProtocol {
       return .endUpdates
     }
   }
-
+  
   public var dataSource: Observable2DArray<SectionMetadata, Item> {
     return source
   }
@@ -340,6 +368,7 @@ extension Observable2DArrayEvent: DataSourceEventProtocol {
 
 extension Observable2DArray: DataSourceProtocol {
 }
+
 
 extension MutableObservable2DArray {
   
@@ -368,30 +397,30 @@ extension MutableObservable2DArray where Item: Equatable {
       lock.lock()
       let diff = sections[index].items.extendedDiff(section.items)
       let patch = diff.patch(from: sections[index].items, to: section.items)
-
+      
       subject.next(Observable2DArrayEvent(change: .beginBatchEditing, source: self))
       sections[index].metadata = section.metadata
       sections[index].items = section.items
-
+      
       for step in patch {
         switch step {
         case .insertion(let patchIndex, _):
           let indexPath = IndexPath(item: patchIndex, section: index)
           subject.next(Observable2DArrayEvent(change: .insertItems([indexPath]), source: self))
-
+          
         case .deletion(let patchIndex):
           let indexPath = IndexPath(item: patchIndex, section: index)
           subject.next(Observable2DArrayEvent(change: .deleteItems([indexPath]), source: self))
-
+          
         case .move(let from, let to):
           let fromIndexPath = IndexPath(item: from, section: index)
           let toIndexPath = IndexPath(item: to, section: index)
-
+          
           subject.next(Observable2DArrayEvent(change: .moveItem(fromIndexPath, toIndexPath), source: self))
           
         }
       }
-
+      
       subject.next(Observable2DArrayEvent(change: .endBatchEditing, source: self))
       lock.unlock()
     } else {
@@ -414,108 +443,88 @@ extension MutableObservable2DArray where Item: Equatable, SectionMetadata: Equat
   public func replace2D(with list: Observable2DArray<SectionMetadata, Item>, performDiff: Bool) {
     
     if performDiff {
+      
       lock.lock()
       
-      // gather old section's metada and new section's metadata
-      let oldSectionsMeta = sections.map({$0.metadata})
-      let newSectionsMeta = list.sections.map({$0.metadata})
+      // perform nested diff
+      let diff = sections.nestedExtendedDiff(to: list.sections, isEqualSection: {(oldSection, newSection) in
+        return oldSection.metadata == newSection.metadata
+      })
       
-      // perform diff on metadata to figure out inserted sections and deleted sections
-      let metaDiff = oldSectionsMeta.extendedDiff(newSectionsMeta)
-      let metaPatch = metaDiff.patch(from: newSectionsMeta, to: newSectionsMeta)
-      
-      //let metaDiff = Array.diff(oldSectionsMeta, newSectionsMeta)
-      
-      var sectionDeletes: [Int] = []
-      var sectionInserts: [Int] = []
-      var sectionMoves: [(from: Int, to: Int)] = []
-      sectionDeletes.reserveCapacity(metaPatch.count)
-      sectionInserts.reserveCapacity(metaPatch.count)
-      sectionMoves.reserveCapacity(metaPatch.count)
-      
-      for diffStep in metaPatch {
-        switch diffStep {
-        case .insertion(let index, _):
-          sectionInserts.append(index)
-        case .deletion(let index):
-          sectionDeletes.append(index)
-        case .move(let from, let to):
-          sectionMoves.append((from,to))
-          //subject.next(ObservableArrayEvent(change: .move(from, to), source: self))
-        }
-      }
-      
-      // get sections that stayed there a.k.a neither deleted nor inserted
-      var sectionsSame: [(new: Int, old: Int)] = []
-      for (i, entry) in newSectionsMeta.enumerated() {
-        if let oldIndex = oldSectionsMeta.index(of: entry) {
-          sectionsSame.append((new: i, old: oldIndex))
-          
-        }
-      }
-      
-      var deletesIndexPaths: [IndexPath] = []
-      var insertsIndexPaths: [IndexPath] = []
-      var movesIndexPaths: [(from: IndexPath, to: IndexPath)] = []
-      
-      // perform diff on sectionsSame items to get indecies that where deleted, inserted and moved inside those sections
-      for entry in sectionsSame {
-        
-        // the diff should happen between old section's items and new section's items on their corresponding indecies
-        let diff = sections[entry.old].items.extendedDiff(list[entry.new].items)
-        let patch = diff.patch(from: sections[entry.old].items, to: list[entry.new].items)
-
-        //let diff = Array.diff(sections[entry.old].items, list[entry.new].items)
-        
-        var deletes: [Int] = []
-        var inserts: [Int] = []
-        deletes.reserveCapacity(diff.count)
-        inserts.reserveCapacity(diff.count)
-
-        
-        for diffStep in patch {
-          switch diffStep {
-          case .insertion(let index, _):
-            inserts.append(index)
-          case .deletion(let index):
-            deletes.append(index)
-          case .move(let from, let to):
-            movesIndexPaths.append((IndexPath(item: from, section: entry.new), IndexPath(item: to, section: entry.new)))
-          }
-        }
-        
-        // deletes should always happen from the old section's place
-        deletesIndexPaths.append(contentsOf: deletes.map { IndexPath(item: $0, section: entry.old) })
-        
-        // insertions should alwyas happen to the new section's place
-        insertsIndexPaths.append(contentsOf: inserts.map { IndexPath(item: $0, section: entry.new) })
-        
-      }
-      
+      let update = NestedBatchUpdate(diff: diff)
       
       subject.next(Observable2DArrayEvent(change: .beginBatchEditing, source: self))
       sections = list.sections
-      subject.next(Observable2DArrayEvent(change: .deleteSections(IndexSet(sectionDeletes)), source: self))
-      subject.next(Observable2DArrayEvent(change: .deleteItems(deletesIndexPaths), source: self))
       
-      for entry in sectionMoves {
-        subject.next(Observable2DArrayEvent(change: .moveSection(entry.from, entry.to), source: self))
+      // item deletion
+      subject.next(Observable2DArrayEvent(change: .deleteItems(update.itemDeletions), source: self))
+      
+      // item insertions
+      subject.next(Observable2DArrayEvent(change: .insertItems(update.itemInsertions), source: self))
+      
+      // item moves
+      update.itemMoves.forEach {
+        subject.next(Observable2DArrayEvent(change: .moveItem($0.from, $0.to) , source: self))
       }
       
-      for entry in movesIndexPaths {
-        subject.next(Observable2DArrayEvent(change: .moveItem(entry.from, entry.to), source: self))
+      // section deletion
+      subject.next(Observable2DArrayEvent(change: .deleteSections(update.sectionDeletions), source: self))
+      
+      // section insertions
+      subject.next(Observable2DArrayEvent(change: .insertSections(update.sectionInsertions), source: self))
+      
+      // section moves
+      update.sectionMoves.forEach {
+        subject.next(Observable2DArrayEvent(change: .moveSection($0.from, $0.to), source: self))
       }
       
-      
-      subject.next(Observable2DArrayEvent(change: .insertSections(IndexSet(sectionInserts)), source: self))
-      subject.next(Observable2DArrayEvent(change: .insertItems(insertsIndexPaths), source: self))
       subject.next(Observable2DArrayEvent(change: .endBatchEditing, source: self))
       lock.unlock()
     } else {
       replace2D(with: list)
     }
   }
-  
 }
 
-
+struct NestedBatchUpdate {
+  let itemDeletions: [IndexPath]
+  let itemInsertions: [IndexPath]
+  let itemMoves: [(from: IndexPath, to: IndexPath)]
+  let sectionDeletions: IndexSet
+  let sectionInsertions: IndexSet
+  let sectionMoves: [(from: Int, to: Int)]
+  
+  init(diff: NestedExtendedDiff) {
+    
+    var itemDeletions: [IndexPath] = []
+    var itemInsertions: [IndexPath] = []
+    var itemMoves: [(IndexPath, IndexPath)] = []
+    var sectionDeletions: IndexSet = []
+    var sectionInsertions: IndexSet = []
+    var sectionMoves: [(from: Int, to: Int)] = []
+    
+    diff.forEach { element in
+      switch element {
+      case let .deleteElement(at, section):
+        itemDeletions.append(IndexPath(item: at, section: section))
+      case let .insertElement(at, section):
+        itemInsertions.append(IndexPath(item: at, section: section))
+      case let .moveElement(from, to):
+        itemMoves.append((IndexPath(item: from.item, section: from.section), IndexPath(item: to.item, section: to.section)))
+      case let .deleteSection(at):
+        sectionDeletions.insert(at)
+      case let .insertSection(at):
+        sectionInsertions.insert(at)
+      case let .moveSection(move):
+        sectionMoves.append(move)
+      }
+    }
+    
+    self.itemInsertions = itemInsertions
+    self.itemDeletions = itemDeletions
+    self.itemMoves = itemMoves
+    self.sectionMoves = sectionMoves
+    self.sectionInsertions = sectionInsertions
+    self.sectionDeletions = sectionDeletions
+  }
+}

--- a/Sources/Collections/Observable2DArray.swift
+++ b/Sources/Collections/Observable2DArray.swift
@@ -292,7 +292,7 @@ extension MutableObservable2DArray: BindableProtocol {
 
   public func bind(signal: Signal<Observable2DArrayEvent<SectionMetadata, Item>, NoError>) -> Disposable {
     return signal
-      .take(until: bnd_deallocated)
+      .take(until: deallocated)
       .observeNext { [weak self] event in
         guard let s = self else { return }
         s.sections = event.source.sections

--- a/Sources/Collections/ObservableArray.swift
+++ b/Sources/Collections/ObservableArray.swift
@@ -43,6 +43,16 @@ public protocol ObservableArrayEventProtocol {
 public struct ObservableArrayEvent<Item>: ObservableArrayEventProtocol {
   public let change: ObservableArrayChange
   public let source: ObservableArray<Item>
+
+  public init(change: ObservableArrayChange, source: ObservableArray<Item>) {
+    self.change = change
+    self.source = source
+  }
+
+  public init(change: ObservableArrayChange, source: [Item]) {
+    self.change = change
+    self.source = ObservableArray(source)
+  }
 }
 
 public class ObservableArray<Item>: Collection, SignalProtocol {

--- a/Sources/Collections/ObservableArray.swift
+++ b/Sources/Collections/ObservableArray.swift
@@ -97,7 +97,7 @@ public class ObservableArray<Item>: Collection, SignalProtocol {
 
 extension ObservableArray: Deallocatable {
 
-  public var bnd_deallocated: Signal<Void, NoError> {
+  public var deallocated: Signal<Void, NoError> {
     return subject.disposeBag.deallocated
   }
 }

--- a/Sources/Collections/ObservableArray.swift
+++ b/Sources/Collections/ObservableArray.swift
@@ -206,7 +206,7 @@ extension MutableObservableArray: BindableProtocol {
 
   public func bind(signal: Signal<ObservableArrayEvent<Item>, NoError>) -> Disposable {
     return signal
-      .take(until: bnd_deallocated)
+      .take(until: deallocated)
       .observeNext { [weak self] event in
         guard let s = self else { return }
         s.array = event.source.array

--- a/Sources/Collections/ObservableDictionary.swift
+++ b/Sources/Collections/ObservableDictionary.swift
@@ -96,7 +96,7 @@ public class ObservableDictionary<Key: Hashable, Value>: Collection, SignalProto
 
 extension ObservableDictionary: Deallocatable {
 
-  public var bnd_deallocated: Signal<Void, NoError> {
+  public var deallocated: Signal<Void, NoError> {
     return subject.disposeBag.deallocated
   }
 }

--- a/Sources/Collections/ObservableDictionary.swift
+++ b/Sources/Collections/ObservableDictionary.swift
@@ -166,7 +166,7 @@ extension MutableObservableDictionary: BindableProtocol {
 
   public func bind(signal: Signal<ObservableDictionaryEvent<Key, Value>, NoError>) -> Disposable {
     return signal
-      .take(until: bnd_deallocated)
+      .take(until: deallocated)
       .observeNext { [weak self] event in
         guard let s = self else { return }
         s.dictionary = event.source.dictionary

--- a/Sources/Collections/ObservableSet.swift
+++ b/Sources/Collections/ObservableSet.swift
@@ -90,7 +90,7 @@ public class ObservableSet<Element: Hashable>: Collection, SignalProtocol {
 
 extension ObservableSet: Deallocatable {
 
-  public var bnd_deallocated: Signal<Void, NoError> {
+  public var deallocated: Signal<Void, NoError> {
     return subject.disposeBag.deallocated
   }
 }

--- a/Sources/Collections/ObservableSet.swift
+++ b/Sources/Collections/ObservableSet.swift
@@ -163,7 +163,7 @@ extension MutableObservableSet: BindableProtocol {
 
   public func bind(signal: Signal<ObservableSetEvent<Element>, NoError>) -> Disposable {
     return signal
-      .take(until: bnd_deallocated)
+      .take(until: deallocated)
       .observeNext { [weak self] event in
         guard let s = self else { return }
         s.set = event.source.set

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -94,7 +94,7 @@ extension Array: DataSourceEventProtocol {
 
 extension SignalProtocol where Element: DataSourceProtocol, Error == NoError {
 
-  public func mapToDataSourceEvent() -> Signal1<DataSourceEvent<Element>> {
+  public func mapToDataSourceEvent() -> SafeSignal<DataSourceEvent<Element>> {
     return map { collection in DataSourceEvent(kind: .reload, dataSource: collection) }
   }
 }

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -53,6 +53,17 @@ public protocol DataSourceEventProtocol {
   var dataSource: DataSource { get }
 }
 
+extension DataSourceEventProtocol {
+
+  public var _unbox: DataSourceEvent<DataSource> {
+    if let event = self as? DataSourceEvent<DataSource> {
+      return event
+    } else {
+      return DataSourceEvent(kind: self.kind, dataSource: self.dataSource)
+    }
+  }
+}
+
 public struct DataSourceEvent<DataSource: DataSourceProtocol>: DataSourceEventProtocol {
   public let kind: DataSourceEventKind
   public let dataSource: DataSource
@@ -67,6 +78,17 @@ extension Array: DataSourceProtocol {
 
   public func numberOfItems(inSection section: Int) -> Int {
     return count
+  }
+}
+
+extension Array: DataSourceEventProtocol {
+
+  public var kind: DataSourceEventKind {
+    return .reload
+  }
+
+  public var dataSource: Array<Element> {
+    return self
   }
 }
 

--- a/Sources/DynamicSubject.swift
+++ b/Sources/DynamicSubject.swift
@@ -25,36 +25,38 @@
 import ReactiveKit
 import Foundation
 
-public struct DynamicSubject2<Target: Deallocatable, Element, Error: Swift.Error>: SubjectProtocol, BindableProtocol {
+public typealias DynamicSubject<Element> = DynamicSubject2<Element, NoError>
 
-  private weak var target: Target?
+public struct DynamicSubject2<Element, Error: Swift.Error>: SubjectProtocol, BindableProtocol {
+
+  private weak var target: AnyObject?
   private var signal: Signal<Void, Error>
-  private let getter: (Target) -> Result<Element, Error>
-  private let setter: (Target, Element) -> Void
+  private let getter: (AnyObject) -> Result<Element, Error>
+  private let setter: (AnyObject, Element) -> Void
   private let subject = PublishSubject<Void, Error>()
   private let triggerEventOnSetting: Bool
 
-  public init(target: Target,
+  public init<Target: Deallocatable>(target: Target,
               signal: Signal<Void, Error>,
               get: @escaping (Target) -> Result<Element, Error>,
               set: @escaping (Target, Element) -> Void,
               triggerEventOnSetting: Bool = true) {
     self.target = target
     self.signal = signal
-    self.getter = get
-    self.setter = set
+    self.getter = { get($0 as! Target) }
+    self.setter = { set($0 as! Target, $1) }
     self.triggerEventOnSetting = triggerEventOnSetting
   }
 
-  public init(target: Target,
+  public init<Target: Deallocatable>(target: Target,
               signal: Signal<Void, Error>,
               get: @escaping (Target) -> Element,
               set: @escaping (Target, Element) -> Void,
               triggerEventOnSetting: Bool = true) {
     self.target = target
     self.signal = signal
-    self.getter = { .success(get($0)) }
-    self.setter = set
+    self.getter = { .success(get($0 as! Target)) }
+    self.setter = { set($0 as! Target, $1) }
     self.triggerEventOnSetting = triggerEventOnSetting
   }
 
@@ -81,7 +83,7 @@ public struct DynamicSubject2<Target: Deallocatable, Element, Error: Swift.Error
       } else {
         return .success(nil)
       }
-      }.ignoreNil().take(until: target.deallocated).observe(with: observer)
+      }.ignoreNil().take(until: (target as! Deallocatable).deallocated).observe(with: observer)
   }
 
   public func bind(signal: Signal<Element, NoError>) -> Disposable {
@@ -89,7 +91,7 @@ public struct DynamicSubject2<Target: Deallocatable, Element, Error: Swift.Error
       let setter = self.setter
       let subject = self.subject
       let triggerEventOnSetting = self.triggerEventOnSetting
-      return signal.take(until: target.deallocated).observe { [weak target] event in
+      return signal.take(until: (target as! Deallocatable).deallocated).observe { [weak target] event in
         ImmediateOnMainExecutionContext { [weak target] in
           switch event {
           case .next(let element):
@@ -124,14 +126,16 @@ public struct DynamicSubject2<Target: Deallocatable, Element, Error: Swift.Error
 
   /// Transform the `getter` and `setter` by applying a `transform` on them.
   public func bidirectionalMap<U>(to getTransform: @escaping (Element) -> U,
-                               from setTransform: @escaping (U) -> Element) -> DynamicSubject2<Target, U, Error>! {
+                               from setTransform: @escaping (U) -> Element) -> DynamicSubject2<U, Error>! {
     guard let target = target else { return nil }
 
-    return DynamicSubject2<Target, U, Error>(
-      target: target,
+    let box = DynamicSubjectMapBox(target)
+
+    return DynamicSubject2<U, Error>(
+      target: box,
       signal: signal,
       get: { [getter] (target) -> Result<U, Error> in
-        switch getter(target) {
+        switch getter(target.object) {
         case .success(let value):
           return .success(getTransform(value))
         case .failure(let error):
@@ -139,10 +143,32 @@ public struct DynamicSubject2<Target: Deallocatable, Element, Error: Swift.Error
         }
       },
       set: { [setter] (target, element) in
-        setter(target, setTransform(element))
+        setter(target.object, setTransform(element))
       }
     )
   }
 }
 
-public typealias DynamicSubject<Target: Deallocatable, Element> = DynamicSubject2<Target, Element, NoError>
+fileprivate class DynamicSubjectMapBox: Deallocatable {
+
+  let object: AnyObject
+
+  init(_ object: AnyObject) {
+    self.object = object
+  }
+
+  var deallocated: Signal<Void, NoError> {
+    return (object as! Deallocatable).deallocated
+  }
+}
+
+extension ReactiveExtensions where Base: Deallocatable {
+
+  public func dynamicSubject<Element>(signal: Signal<Void, NoError>,
+                             triggerEventOnSetting: Bool = true,
+                             get: @escaping (Base) -> Element,
+                             set: @escaping (Base, Element) -> Void) -> DynamicSubject<Element> {
+    return DynamicSubject(target: base, signal: signal, get: get, set: set, triggerEventOnSetting: triggerEventOnSetting)
+  }
+}
+

--- a/Sources/DynamicSubject.swift
+++ b/Sources/DynamicSubject.swift
@@ -81,7 +81,7 @@ public struct DynamicSubject2<Target: Deallocatable, Element, Error: Swift.Error
       } else {
         return .success(nil)
       }
-      }.ignoreNil().take(until: target.bnd_deallocated).observe(with: observer)
+      }.ignoreNil().take(until: target.deallocated).observe(with: observer)
   }
 
   public func bind(signal: Signal<Element, NoError>) -> Disposable {
@@ -89,7 +89,7 @@ public struct DynamicSubject2<Target: Deallocatable, Element, Error: Swift.Error
       let setter = self.setter
       let subject = self.subject
       let triggerEventOnSetting = self.triggerEventOnSetting
-      return signal.take(until: target.bnd_deallocated).observe { [weak target] event in
+      return signal.take(until: target.deallocated).observe { [weak target] event in
         ImmediateOnMainExecutionContext { [weak target] in
           switch event {
           case .next(let element):

--- a/Sources/Observable2DArray.swift
+++ b/Sources/Observable2DArray.swift
@@ -136,6 +136,13 @@ public class Observable2DArray<SectionMetadata, Item>: Collection, SignalProtoco
   }
 }
 
+extension Observable2DArray: Deallocatable {
+
+  public var bnd_deallocated: Signal<Void, NoError> {
+    return subject.disposeBag.deallocated
+  }
+}
+
 public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<SectionMetadata, Item> {
 
   /// Append new section at the end of the 2D array.

--- a/Sources/ObservableArray.swift
+++ b/Sources/ObservableArray.swift
@@ -95,6 +95,13 @@ public class ObservableArray<Item>: Collection, SignalProtocol {
   }
 }
 
+extension ObservableArray: Deallocatable {
+
+  public var bnd_deallocated: Signal<Void, NoError> {
+    return subject.disposeBag.deallocated
+  }
+}
+
 extension ObservableArray where Item: Equatable {
   
   public static func ==(lhs: ObservableArray<Item>, rhs: ObservableArray<Item>) -> Bool {

--- a/Sources/ObservableDictionary.swift
+++ b/Sources/ObservableDictionary.swift
@@ -94,6 +94,13 @@ public class ObservableDictionary<Key: Hashable, Value>: Collection, SignalProto
   }
 }
 
+extension ObservableDictionary: Deallocatable {
+
+  public var bnd_deallocated: Signal<Void, NoError> {
+    return subject.disposeBag.deallocated
+  }
+}
+
 public class MutableObservableDictionary<Key: Hashable, Value>: ObservableDictionary<Key, Value> {
 
   public override subscript (key: Key) -> Value? {

--- a/Sources/ObservableSet.swift
+++ b/Sources/ObservableSet.swift
@@ -88,6 +88,13 @@ public class ObservableSet<Element: Hashable>: Collection, SignalProtocol {
   }
 }
 
+extension ObservableSet: Deallocatable {
+
+  public var bnd_deallocated: Signal<Void, NoError> {
+    return subject.disposeBag.deallocated
+  }
+}
+
 public class MutableObservableSet<Element: Hashable>: ObservableSet<Element> {
 
   /// Return `true`  if a member is the set.

--- a/Sources/ProtocolProxy.swift
+++ b/Sources/ProtocolProxy.swift
@@ -115,7 +115,7 @@ public class ProtocolProxy: BNDProtocolProxyBase {
     registerDelegate()
   }
 
-  private func _signal<S>(for selector: Selector, registerInvoker: (PublishSubject1<S>) -> Void) -> Signal1<S>{
+  private func _signal<S>(for selector: Selector, registerInvoker: (PublishSubject1<S>) -> Void) -> SafeSignal<S>{
     if let signal = handlers[selector] {
       return (signal as! PublishSubject1<S>).toSignal()
     } else {
@@ -131,7 +131,7 @@ public class ProtocolProxy: BNDProtocolProxyBase {
   ///
   /// - parameter selector: Selector of the method to map.
   /// - parameter dispatch: A closure that dispatches calls to the given PublishSubject.
-  public func signal<S, R>(for selector: Selector, dispatch: @escaping (PublishSubject<S, NoError>) -> R) -> Signal1<S> {
+  public func signal<S, R>(for selector: Selector, dispatch: @escaping (PublishSubject<S, NoError>) -> R) -> SafeSignal<S> {
     return _signal(for: selector) { subject in
       registerInvoker(for: selector) { () -> R in
         return dispatch(subject)
@@ -147,7 +147,7 @@ public class ProtocolProxy: BNDProtocolProxyBase {
   ///
   /// - important: This is ObjC API so you have to use ObjC types like NSString instead of String
   /// in place of generic parameter A and R!
-  public func signal<A, S, R>(for selector: Selector, dispatch: @escaping (PublishSubject<S, NoError>, A) -> R) -> Signal1<S> {
+  public func signal<A, S, R>(for selector: Selector, dispatch: @escaping (PublishSubject<S, NoError>, A) -> R) -> SafeSignal<S> {
     return _signal(for: selector) { subject in
       registerInvoker(for: selector) { (a: A) -> R in
         return dispatch(subject, a)
@@ -163,7 +163,7 @@ public class ProtocolProxy: BNDProtocolProxyBase {
   ///
   /// - important: This is ObjC API so you have to use ObjC types like NSString instead of String
   /// in place of generic parameters A, B and R!
-  public func signal<A, B, S, R>(for selector: Selector, dispatch: @escaping (PublishSubject<S, NoError>, A, B) -> R) -> Signal1<S> {
+  public func signal<A, B, S, R>(for selector: Selector, dispatch: @escaping (PublishSubject<S, NoError>, A, B) -> R) -> SafeSignal<S> {
     return _signal(for: selector) { subject in
       registerInvoker(for: selector) { (a: A, b: B) -> R in
         return dispatch(subject, a, b)
@@ -179,7 +179,7 @@ public class ProtocolProxy: BNDProtocolProxyBase {
   ///
   /// - important: This is ObjC API so you have to use ObjC types like NSString instead of String
   /// in place of generic parameters A, B, C and R!
-  public func signal<A, B, C, S, R>(for selector: Selector, dispatch: @escaping (PublishSubject<S, NoError>, A, B, C) -> R) -> Signal1<S> {
+  public func signal<A, B, C, S, R>(for selector: Selector, dispatch: @escaping (PublishSubject<S, NoError>, A, B, C) -> R) -> SafeSignal<S> {
     return _signal(for: selector) { subject in
       registerInvoker(for: selector) { (a: A, b: B, c: C) -> R in
         return dispatch(subject, a, b, c)
@@ -195,7 +195,7 @@ public class ProtocolProxy: BNDProtocolProxyBase {
   ///
   /// - important: This is ObjC API so you have to use ObjC types like NSString instead of String
   /// in place of generic parameters A, B, C, D and R!
-  public func signal<A, B, C, D, S, R>(for selector: Selector, dispatch: @escaping (PublishSubject<S, NoError>, A, B, C, D) -> R) -> Signal1<S> {
+  public func signal<A, B, C, D, S, R>(for selector: Selector, dispatch: @escaping (PublishSubject<S, NoError>, A, B, C, D) -> R) -> SafeSignal<S> {
     return _signal(for: selector) { subject in
       registerInvoker(for: selector) { (a: A, b: B, c: C, d: D) -> R in
         return dispatch(subject, a, b, c, d)
@@ -211,7 +211,7 @@ public class ProtocolProxy: BNDProtocolProxyBase {
   ///
   /// - important: This is ObjC API so you have to use ObjC types like NSString instead of String
   /// in place of generic parameters A, B, C, D, E and R!
-  public func signal<A, B, C, D, E, S, R>(for selector: Selector, dispatch: @escaping (PublishSubject<S, NoError>, A, B, C, D, E) -> R) -> Signal1<S> {
+  public func signal<A, B, C, D, E, S, R>(for selector: Selector, dispatch: @escaping (PublishSubject<S, NoError>, A, B, C, D, E) -> R) -> SafeSignal<S> {
     return _signal(for: selector) { subject in
       registerInvoker(for: selector) { (a: A, b: B, c: C, d: D, e: E) -> R in
         return dispatch(subject, a, b, c, d, e)

--- a/Sources/Shared/CALayer.swift
+++ b/Sources/Shared/CALayer.swift
@@ -22,15 +22,20 @@
 //  THE SOFTWARE.
 //
 
-#if os(OSX)
-  import AppKit
-#else
-  import UIKit
-#endif
+import QuartzCore
+import ReactiveKit
 
-public extension NSLayoutConstraint {
+public extension ReactiveExtensions where Base: CALayer {
 
-  public var bnd_isActive: Bond<NSLayoutConstraint, Bool> {
-    return Bond(target: self) { $0.isActive = $1 }
+  public var opacity: Bond<Float> {
+    return bond { $0.opacity = $1 }
+  }
+
+  public var backgroundColor: Bond<CGColor?> {
+    return bond { $0.backgroundColor = $1 }
+  }
+
+  public var contents: Bond<AnyObject?> {
+    return bond { $0.contents = $1 }
   }
 }

--- a/Sources/Shared/NSLayoutConstraint.swift
+++ b/Sources/Shared/NSLayoutConstraint.swift
@@ -22,21 +22,17 @@
 //  THE SOFTWARE.
 //
 
+#if os(OSX)
+  import AppKit
+#else
+  import UIKit
+#endif
 
-import QuartzCore
 import ReactiveKit
 
-public extension CALayer {
+public extension ReactiveExtensions where Base: NSLayoutConstraint {
 
-  public var bnd_opacity: Bond<CALayer, Float> {
-    return Bond(target: self) { $0.opacity = $1 }
-  }
-
-  public var bnd_backgroundColor: Bond<CALayer, CGColor?> {
-    return Bond(target: self) { $0.backgroundColor = $1 }
-  }
-
-  public var bnd_contents: Bond<CALayer, AnyObject?> {
-    return Bond(target: self) { $0.contents = $1 }
+  public var isActive: Bond<Bool> {
+    return bond { $0.isActive = $1 }
   }
 }

--- a/Sources/Shared/NSObject+KVO.swift
+++ b/Sources/Shared/NSObject+KVO.swift
@@ -148,7 +148,7 @@ private class RKKeyValueSignal: NSObject, SignalProtocol {
   private weak var object: NSObject? = nil
   private var context = 0
   private var keyPath: String
-  private let subject: AnySubject<Void, NoError>
+  private let subject: Subject<Void, NoError>
   private var numberOfObservers: Int = 0
   private var observing = false
   private let deallocationDisposable = SerialDisposable(otherDisposable: nil)
@@ -156,7 +156,7 @@ private class RKKeyValueSignal: NSObject, SignalProtocol {
   
   fileprivate init(keyPath: String, for object: NSObject) {
     self.keyPath = keyPath
-    self.subject = AnySubject(base: PublishSubject())
+    self.subject = PublishSubject()
     self.object = object
     super.init()
 

--- a/Sources/Shared/NSObject+KVO.swift
+++ b/Sources/Shared/NSObject+KVO.swift
@@ -26,19 +26,21 @@ import Foundation
 import ReactiveKit
 
 public extension NSObject {
-
   public enum KVOError: Error {
     case notConvertible(String)
   }
+}
+
+public extension ReactiveExtensions where Base: NSObject {
 
   /// Returns a ```DynamicSubject``` representing the given KVO path of the given type.
   ///
   /// E.g. ```user.dynamic(keyPath: "name", ofType: String.self)```
   ///
-  public func dynamic<T>(keyPath: String, ofType: T.Type) -> DynamicSubject<NSObject, T> {
+  public func keyPath<T>(_ keyPath: String, ofType: T.Type) -> DynamicSubject<NSObject, T> {
     return DynamicSubject(
-      target: self,
-      signal: RKKeyValueSignal(keyPath: keyPath, for: self).toSignal(),
+      target: base,
+      signal: RKKeyValueSignal(keyPath: keyPath, for: base).toSignal(),
       get: { (target) -> T in
         let maybeValue = target.value(forKeyPath: keyPath)
         if let value = maybeValue as? T {
@@ -58,10 +60,10 @@ public extension NSObject {
   ///
   /// E.g. ```user.dynamic(keyPath: "name", ofType: Optional<String>.self)```
   ///
-  public func dynamic<T>(keyPath: String, ofType: T.Type) -> DynamicSubject<NSObject, T> where T: OptionalProtocol {
+  public func keyPath<T>(_ keyPath: String, ofType: T.Type) -> DynamicSubject<NSObject, T> where T: OptionalProtocol {
     return DynamicSubject(
-      target: self,
-      signal: RKKeyValueSignal(keyPath: keyPath, for: self).toSignal(),
+      target: base,
+      signal: RKKeyValueSignal(keyPath: keyPath, for: base).toSignal(),
       get: { (target) -> T in
         let maybeValue = target.value(forKeyPath: keyPath)
         if let value = maybeValue as? T {
@@ -89,11 +91,11 @@ public extension NSObject {
   ///
   /// E.g. ```user.dynamic(keyPath: "name", ofType: String.self)```
   ///
-  public func dynamic<T>(keyPath: String, ofExpectedType: T.Type) -> DynamicSubject2<NSObject, T, KVOError> {
+  public func keyPath<T>(_ keyPath: String, ofExpectedType: T.Type) -> DynamicSubject2<NSObject, T, NSObject.KVOError> {
     return DynamicSubject2(
-      target: self,
-      signal: RKKeyValueSignal(keyPath: keyPath, for: self).castError(),
-      get: { (target) -> Result<T, KVOError> in
+      target: base,
+      signal: RKKeyValueSignal(keyPath: keyPath, for: base).castError(),
+      get: { (target) -> Result<T, NSObject.KVOError> in
         let maybeValue = target.value(forKeyPath: keyPath)
         if let value = maybeValue as? T {
           return .success(value)
@@ -114,11 +116,11 @@ public extension NSObject {
   ///
   /// E.g. ```user.dynamic(keyPath: "name", ofType: Optional<String>.self)```
   ///
-  public func dynamic<T>(keyPath: String, ofExpectedType: T.Type) -> DynamicSubject2<NSObject, T, KVOError> where T: OptionalProtocol {
+  public func keyPath<T>(_ keyPath: String, ofExpectedType: T.Type) -> DynamicSubject2<NSObject, T, NSObject.KVOError> where T: OptionalProtocol {
     return DynamicSubject2(
-      target: self,
-      signal: RKKeyValueSignal(keyPath: keyPath, for: self).castError(),
-      get: { (target) -> Result<T, KVOError> in
+      target: base,
+      signal: RKKeyValueSignal(keyPath: keyPath, for: base).castError(),
+      get: { (target) -> Result<T, NSObject.KVOError> in
         let maybeValue = target.value(forKeyPath: keyPath)
         if let value = maybeValue as? T {
           return .success(value)

--- a/Sources/Shared/NSObject+KVO.swift
+++ b/Sources/Shared/NSObject+KVO.swift
@@ -37,7 +37,7 @@ public extension ReactiveExtensions where Base: NSObject {
   ///
   /// E.g. ```user.dynamic(keyPath: "name", ofType: String.self)```
   ///
-  public func keyPath<T>(_ keyPath: String, ofType: T.Type) -> DynamicSubject<NSObject, T> {
+  public func keyPath<T>(_ keyPath: String, ofType: T.Type) -> DynamicSubject<T> {
     return DynamicSubject(
       target: base,
       signal: RKKeyValueSignal(keyPath: keyPath, for: base).toSignal(),
@@ -60,7 +60,7 @@ public extension ReactiveExtensions where Base: NSObject {
   ///
   /// E.g. ```user.dynamic(keyPath: "name", ofType: Optional<String>.self)```
   ///
-  public func keyPath<T>(_ keyPath: String, ofType: T.Type) -> DynamicSubject<NSObject, T> where T: OptionalProtocol {
+  public func keyPath<T>(_ keyPath: String, ofType: T.Type) -> DynamicSubject<T> where T: OptionalProtocol {
     return DynamicSubject(
       target: base,
       signal: RKKeyValueSignal(keyPath: keyPath, for: base).toSignal(),
@@ -91,7 +91,7 @@ public extension ReactiveExtensions where Base: NSObject {
   ///
   /// E.g. ```user.dynamic(keyPath: "name", ofType: String.self)```
   ///
-  public func keyPath<T>(_ keyPath: String, ofExpectedType: T.Type) -> DynamicSubject2<NSObject, T, NSObject.KVOError> {
+  public func keyPath<T>(_ keyPath: String, ofExpectedType: T.Type) -> DynamicSubject2<T, NSObject.KVOError> {
     return DynamicSubject2(
       target: base,
       signal: RKKeyValueSignal(keyPath: keyPath, for: base).castError(),
@@ -116,7 +116,7 @@ public extension ReactiveExtensions where Base: NSObject {
   ///
   /// E.g. ```user.dynamic(keyPath: "name", ofType: Optional<String>.self)```
   ///
-  public func keyPath<T>(_ keyPath: String, ofExpectedType: T.Type) -> DynamicSubject2<NSObject, T, NSObject.KVOError> where T: OptionalProtocol {
+  public func keyPath<T>(_ keyPath: String, ofExpectedType: T.Type) -> DynamicSubject2<T, NSObject.KVOError> where T: OptionalProtocol {
     return DynamicSubject2(
       target: base,
       signal: RKKeyValueSignal(keyPath: keyPath, for: base).castError(),

--- a/Sources/Shared/NSObject.swift
+++ b/Sources/Shared/NSObject.swift
@@ -26,18 +26,39 @@
 import Foundation
 import ReactiveKit
 
+extension NSObject: ReactiveExtensionsProvider {}
+
+extension ReactiveExtensions where Base: NSObject {
+
+  /// A signal that fires completion event when the object is deallocated.
+  public var deallocated: SafeSignal<Void> {
+    return base.deallocated
+  }
+
+  /// Use this bag to dispose disposables upon the deallocation of the receiver.
+  public var bag: DisposeBag {
+    if let disposeBag = objc_getAssociatedObject(base, &NSObject.AssociatedKeys.DisposeBagKey) {
+      return disposeBag as! DisposeBag
+    } else {
+      let disposeBag = DisposeBag()
+      objc_setAssociatedObject(base, &NSObject.AssociatedKeys.DisposeBagKey, disposeBag, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+      return disposeBag
+    }
+  }
+}
+
 public protocol Deallocatable: class {
-  var bnd_deallocated: Signal<Void, NoError> { get }
+  var deallocated: Signal<Void, NoError> { get }
 }
 
 extension NSObject: Deallocatable {
 
-  private struct AssociatedKeys {
-    static var DeallocationSignalHelper = "DeallocationSignalHelper"
-    static var DisposeBagKey = "r_DisposeBagKey"
+  fileprivate struct AssociatedKeys {
+    static var DeallocationSignalHelper = "bnd_DeallocationSignalHelper"
+    static var DisposeBagKey = "bnd_DisposeBagKey"
   }
 
-  private class BNDDeallocationSignalHelper {
+  fileprivate class BNDDeallocationSignalHelper {
     let subject = ReplayOneSubject<Void, NoError>()
     deinit {
       subject.completed()
@@ -45,7 +66,7 @@ extension NSObject: Deallocatable {
   }
 
   /// A signal that fires completion event when the object is deallocated.
-  public var bnd_deallocated: Signal<Void, NoError> {
+  public var deallocated: Signal<Void, NoError> {
     if let helper = objc_getAssociatedObject(self, &AssociatedKeys.DeallocationSignalHelper) as? BNDDeallocationSignalHelper {
       return helper.subject.toSignal()
     } else {
@@ -54,27 +75,16 @@ extension NSObject: Deallocatable {
       return helper.subject.toSignal()
     }
   }
-  
-  /// Use this bag to dispose disposables upon the deallocation of the receiver.
-  public var bnd_bag: DisposeBag {
-    if let disposeBag = objc_getAssociatedObject(self, &AssociatedKeys.DisposeBagKey) {
-      return disposeBag as! DisposeBag
-    } else {
-      let disposeBag = DisposeBag()
-      objc_setAssociatedObject(self, &AssociatedKeys.DisposeBagKey, disposeBag, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-      return disposeBag
-    }
-  }
 
   /// Bind `signal` to `bindable` and dispose in `bnd_bag` of receiver.
   @discardableResult
   public func bind<O: SignalProtocol, B: BindableProtocol>(_ signal: O, to bindable: B) where O.Element == B.Element, O.Error == NoError {
-    signal.bind(to: bindable).disposeIn(bnd_bag)
+    signal.bind(to: bindable).disposeIn(reactive.bag)
   }
   
   /// Bind `signal` to `bindable` and dispose in `bnd_bag` of receiver.
   @discardableResult
   public func bind<O: SignalProtocol, B: BindableProtocol>(_ signal: O, to bindable: B) where B.Element: OptionalProtocol, O.Element == B.Element.Wrapped, O.Error == NoError {
-    signal.bind(to: bindable).disposeIn(bnd_bag)
+    signal.bind(to: bindable).disposeIn(reactive.bag)
   }
 }

--- a/Sources/Shared/NSObject.swift
+++ b/Sources/Shared/NSObject.swift
@@ -79,12 +79,12 @@ extension NSObject: Deallocatable {
   /// Bind `signal` to `bindable` and dispose in `bnd_bag` of receiver.
   @discardableResult
   public func bind<O: SignalProtocol, B: BindableProtocol>(_ signal: O, to bindable: B) where O.Element == B.Element, O.Error == NoError {
-    signal.bind(to: bindable).disposeIn(reactive.bag)
+    signal.bind(to: bindable).dispose(in: reactive.bag)
   }
   
   /// Bind `signal` to `bindable` and dispose in `bnd_bag` of receiver.
   @discardableResult
   public func bind<O: SignalProtocol, B: BindableProtocol>(_ signal: O, to bindable: B) where B.Element: OptionalProtocol, O.Element == B.Element.Wrapped, O.Error == NoError {
-    signal.bind(to: bindable).disposeIn(reactive.bag)
+    signal.bind(to: bindable).dispose(in: reactive.bag)
   }
 }

--- a/Sources/Shared/NSObject.swift
+++ b/Sources/Shared/NSObject.swift
@@ -22,7 +22,6 @@
 //  THE SOFTWARE.
 //
 
-
 import Foundation
 import ReactiveKit
 
@@ -32,7 +31,7 @@ extension ReactiveExtensions where Base: NSObject {
 
   /// A signal that fires completion event when the object is deallocated.
   public var deallocated: SafeSignal<Void> {
-    return base.deallocated
+    return bag.deallocated
   }
 
   /// Use this bag to dispose disposables upon the deallocation of the receiver.
@@ -54,26 +53,12 @@ public protocol Deallocatable: class {
 extension NSObject: Deallocatable {
 
   fileprivate struct AssociatedKeys {
-    static var DeallocationSignalHelper = "bnd_DeallocationSignalHelper"
     static var DisposeBagKey = "bnd_DisposeBagKey"
-  }
-
-  fileprivate class BNDDeallocationSignalHelper {
-    let subject = ReplayOneSubject<Void, NoError>()
-    deinit {
-      subject.completed()
-    }
   }
 
   /// A signal that fires completion event when the object is deallocated.
   public var deallocated: Signal<Void, NoError> {
-    if let helper = objc_getAssociatedObject(self, &AssociatedKeys.DeallocationSignalHelper) as? BNDDeallocationSignalHelper {
-      return helper.subject.toSignal()
-    } else {
-      let helper = BNDDeallocationSignalHelper()
-      objc_setAssociatedObject(self, &AssociatedKeys.DeallocationSignalHelper, helper, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-      return helper.subject.toSignal()
-    }
+    return reactive.deallocated
   }
 
   /// Bind `signal` to `bindable` and dispose in `bnd_bag` of receiver.

--- a/Sources/Shared/NotificationCenter.swift
+++ b/Sources/Shared/NotificationCenter.swift
@@ -25,16 +25,16 @@
 import Foundation
 import ReactiveKit
 
-extension NotificationCenter {
+public extension ReactiveExtensions where Base: NotificationCenter {
   
   /// Observe notifications using a signal.
-  public func bnd_notification(name: NSNotification.Name, object: AnyObject? = nil) -> Signal<Notification, NoError> {
+  public func notification(name: NSNotification.Name, object: AnyObject? = nil) -> Signal<Notification, NoError> {
     return Signal { observer in
-      let subscription = self.addObserver(forName: name, object: object, queue: nil, using: { notification in
+      let subscription = self.base.addObserver(forName: name, object: object, queue: nil, using: { notification in
         observer.next(notification)
       })
       return BlockDisposable {
-        self.removeObserver(subscription)
+        self.base.removeObserver(subscription)
       }
     }
   }

--- a/Sources/Shared/SignalProtocol.swift
+++ b/Sources/Shared/SignalProtocol.swift
@@ -10,6 +10,8 @@ import ReactiveKit
 
 extension SignalProtocol {
 
+  #if os(iOS) || os(tvOS)
+
   /// Fires an event on start and every `interval` seconds as long as the app is in foreground.
   /// Pauses when the app goes to background. Restarts when the app is back in foreground.
   public static func heartbeat(interval seconds: Double) -> Signal<Void, NoError> {
@@ -19,4 +21,6 @@ extension SignalProtocol {
       return Signal<Int, NoError>.interval(seconds, queue: .global()).replace(with: ()).start(with: ()).take(until: didEnterBackgorund)
     }
   }
+
+  #endif
 }

--- a/Sources/Shared/SignalProtocol.swift
+++ b/Sources/Shared/SignalProtocol.swift
@@ -13,8 +13,8 @@ extension SignalProtocol {
   /// Fires an event on start and every `interval` seconds as long as the app is in foreground.
   /// Pauses when the app goes to background. Restarts when the app is back in foreground.
   public static func heartbeat(interval seconds: Double) -> Signal<Void, NoError> {
-    let willEnterForeground = NotificationCenter.default.bnd_notification(name: .UIApplicationWillEnterForeground)
-    let didEnterBackgorund = NotificationCenter.default.bnd_notification(name: .UIApplicationDidEnterBackground)
+    let willEnterForeground = NotificationCenter.default.reactive.notification(name: .UIApplicationWillEnterForeground)
+    let didEnterBackgorund = NotificationCenter.default.reactive.notification(name: .UIApplicationDidEnterBackground)
     return willEnterForeground.replace(with: ()).start(with: ()).flatMapLatest { () -> Signal<Void, NoError> in
       return Signal<Int, NoError>.interval(seconds, queue: .global()).replace(with: ()).start(with: ()).take(until: didEnterBackgorund)
     }

--- a/Sources/SignalProtocol.swift
+++ b/Sources/SignalProtocol.swift
@@ -1,0 +1,22 @@
+//
+//  SignalProtocol.swift
+//  Bond
+//
+//  Created by Srdan Rasic on 14/12/2016.
+//  Copyright © 2016 Swift Bond. All rights reserved.
+//
+
+import ReactiveKit
+
+extension SignalProtocol {
+
+  /// Fires an event on start and every `interval` seconds as long as the app is in foreground.
+  /// Pauses when the app goes to background. Restarts when the app is back in foreground.
+  public static func heartbeat(interval seconds: Double) -> Signal<Void, NoError> {
+    let willEnterForeground = NotificationCenter.default.bnd_notification(name: .UIApplicationWillEnterForeground)
+    let didEnterBackgorund = NotificationCenter.default.bnd_notification(name: .UIApplicationDidEnterBackground)
+    return willEnterForeground.replace(with: ()).start(with: ()).flatMapLatest { () -> Signal<Void, NoError> in
+      return Signal<Int, NoError>.interval(seconds, queue: .global()).replace(with: ()).start(with: ()).take(until: didEnterBackgorund)
+    }
+  }
+}

--- a/Sources/UIKit/UIActivityIndicatorView.swift
+++ b/Sources/UIKit/UIActivityIndicatorView.swift
@@ -22,13 +22,13 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import UIKit
+import ReactiveKit
 
-public extension UIActivityIndicatorView {
+public extension ReactiveExtensions where Base: UIActivityIndicatorView  {
 
-  public var bnd_animating: Bond<UIActivityIndicatorView, Bool> {
-    return Bond(target: self) {
+  public var animating: Bond<Bool> {
+    return bond {
       if $1 {
         $0.startAnimating()
       } else {
@@ -41,6 +41,6 @@ public extension UIActivityIndicatorView {
 extension UIActivityIndicatorView: BindableProtocol {
 
   public func bind(signal: Signal<Bool, NoError>) -> Disposable {
-    return bnd_animating.bind(signal: signal)
+    return reactive.animating.bind(signal: signal)
   }
 }

--- a/Sources/UIKit/UIApplication.swift
+++ b/Sources/UIKit/UIApplication.swift
@@ -23,12 +23,13 @@
 //
 
 import UIKit
+import ReactiveKit
 
-extension UIApplication {
+public extension ReactiveExtensions where Base: UIApplication {
 
   #if os(iOS)
-  public var bnd_isNetworkActivityIndicatorVisible: Bond<UIApplication, Bool> {
-    return Bond(target: self) { $0.isNetworkActivityIndicatorVisible = $1 }
+  public var isNetworkActivityIndicatorVisible: Bond<Bool> {
+    return bond { $0.isNetworkActivityIndicatorVisible = $1 }
   }
   #endif
 }

--- a/Sources/UIKit/UIBarButtonItem.swift
+++ b/Sources/UIKit/UIBarButtonItem.swift
@@ -27,41 +27,44 @@ import ReactiveKit
 
 extension UIBarButtonItem {
 
-  private struct AssociatedKeys {
+  fileprivate struct AssociatedKeys {
     static var BarButtonItemHelperKey = "bnd_BarButtonItemHelperKey"
   }
 
-  public var bnd_tap: Signal1<Void> {
-    if let target = objc_getAssociatedObject(self, &AssociatedKeys.BarButtonItemHelperKey) as AnyObject? {
-      return (target as! BNDBarButtonItemTarget).subject.toSignal()
-    } else {
-      let target = BNDBarButtonItemTarget(barButtonItem: self)
-      objc_setAssociatedObject(self, &AssociatedKeys.BarButtonItemHelperKey, target, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-      return target.subject.toSignal()
+  @objc fileprivate class BondTarget: NSObject
+  {
+    weak var barButtonItem: UIBarButtonItem?
+    let subject = PublishSubject<Void, NoError>()
+
+    init(barButtonItem: UIBarButtonItem) {
+      self.barButtonItem = barButtonItem
+      super.init()
+
+      barButtonItem.target = self
+      barButtonItem.action = #selector(eventHandler)
+    }
+
+    func eventHandler() {
+      subject.next()
+    }
+
+    deinit {
+      barButtonItem?.target = nil
+      barButtonItem?.action = nil
+      subject.completed()
     }
   }
 }
 
-@objc fileprivate class BNDBarButtonItemTarget: NSObject
-{
-  weak var barButtonItem: UIBarButtonItem?
-  let subject = PublishSubject<Void, NoError>()
+public extension ReactiveExtensions where Base: UIBarButtonItem {
 
-  init(barButtonItem: UIBarButtonItem) {
-    self.barButtonItem = barButtonItem
-    super.init()
-
-    barButtonItem.target = self
-    barButtonItem.action = #selector(eventHandler)
-  }
-
-  func eventHandler() {
-    subject.next()
-  }
-
-  deinit {
-    barButtonItem?.target = nil
-    barButtonItem?.action = nil
-    subject.completed()
+  public var tap: SafeSignal<Void> {
+    if let target = objc_getAssociatedObject(base, &UIBarButtonItem.AssociatedKeys.BarButtonItemHelperKey) as AnyObject? {
+      return (target as! UIBarButtonItem.BondTarget).subject.toSignal()
+    } else {
+      let target = UIBarButtonItem.BondTarget(barButtonItem: base)
+      objc_setAssociatedObject(base, &UIBarButtonItem.AssociatedKeys.BarButtonItemHelperKey, target, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+      return target.subject.toSignal()
+    }
   }
 }

--- a/Sources/UIKit/UIBarItem.swift
+++ b/Sources/UIKit/UIBarItem.swift
@@ -23,18 +23,19 @@
 //
 
 import UIKit
+import ReactiveKit
 
-public extension UIBarItem {
+public extension ReactiveExtensions where Base: UIBarItem {
 
-  public var bnd_title: Bond<UIBarItem, String?> {
-    return Bond(target: self) { $0.title = $1 }
+  public var title: Bond<String?> {
+    return bond { $0.title = $1 }
   }
 
-  public var bnd_image: Bond<UIBarItem, UIImage?> {
-    return Bond(target: self) { $0.image = $1 }
+  public var image: Bond<UIImage?> {
+    return bond { $0.image = $1 }
   }
 
-  public var bnd_isEnabled: Bond<UIBarItem, Bool> {
-    return Bond(target: self) { $0.isEnabled = $1 }
+  public var isEnabled: Bond<Bool> {
+    return bond { $0.isEnabled = $1 }
   }
 }

--- a/Sources/UIKit/UIButton.swift
+++ b/Sources/UIKit/UIButton.swift
@@ -25,21 +25,21 @@
 import UIKit
 import ReactiveKit
 
-public extension UIButton {
+public extension ReactiveExtensions where Base: UIButton {
 
-  public var bnd_title: Bond<UIButton, String?> {
-    return Bond(target: self) { $0.setTitle($1, for: .normal) }
+  public var title: Bond<String?> {
+    return bond { $0.setTitle($1, for: .normal) }
   }
 
-  public var bnd_tap: Signal<Void, NoError> {
-    return bnd_controlEvents(.touchUpInside)
+  public var tap: SafeSignal<Void> {
+    return controlEvents(.touchUpInside)
   }
 
-  public var bnd_isSelected: Bond<UIButton, Bool> {
-    return Bond(target: self) { $0.isSelected = $1 }
+  public var isSelected: Bond<Bool> {
+    return bond { $0.isSelected = $1 }
   }
 
-  public var bnd_isHighlighted: Bond<UIButton, Bool> {
-    return Bond(target: self) { $0.isHighlighted = $1 }
+  public var isHighlighted: Bond<Bool> {
+    return bond { $0.isHighlighted = $1 }
   }
 }

--- a/Sources/UIKit/UICollectionView.swift
+++ b/Sources/UIKit/UICollectionView.swift
@@ -39,14 +39,14 @@ private struct SimpleCollectionViewBond<DataSource: DataSourceProtocol>: Collect
   }
 }
 
-public extension UICollectionView {
+public extension ReactiveExtensions where Base: UICollectionView {
 
-  public var bnd_delegate: ProtocolProxy {
-    return protocolProxy(for: UICollectionViewDelegate.self, setter: NSSelectorFromString("setDelegate:"))
+  public var delegate: ProtocolProxy {
+    return base.protocolProxy(for: UICollectionViewDelegate.self, setter: NSSelectorFromString("setDelegate:"))
   }
 
-  public var bnd_dataSource: ProtocolProxy {
-    return protocolProxy(for: UICollectionViewDataSource.self, setter: NSSelectorFromString("setDataSource:"))
+  public var dataSource: ProtocolProxy {
+    return base.protocolProxy(for: UICollectionViewDataSource.self, setter: NSSelectorFromString("setDataSource:"))
   }
 }
 
@@ -62,20 +62,20 @@ public extension SignalProtocol where Element: DataSourceEventProtocol, Error ==
 
     let dataSource = Property<DataSource?>(nil)
 
-    collectionView.bnd_dataSource.feed(
+    collectionView.reactive.dataSource.feed(
       property: dataSource,
       to: #selector(UICollectionViewDataSource.collectionView(_:cellForItemAt:)),
       map: { (dataSource: DataSource?, collectionView: UICollectionView, indexPath: NSIndexPath) -> UICollectionViewCell in
         return bond.cellForRow(at: indexPath as IndexPath, collectionView: collectionView, dataSource: dataSource!)
     })
 
-    collectionView.bnd_dataSource.feed(
+    collectionView.reactive.dataSource.feed(
       property: dataSource,
       to: #selector(UICollectionViewDataSource.collectionView(_:numberOfItemsInSection:)),
       map: { (dataSource: DataSource?, _: UICollectionView, section: Int) -> Int in dataSource?.numberOfItems(inSection: section) ?? 0 }
     )
 
-    collectionView.bnd_dataSource.feed(
+    collectionView.reactive.dataSource.feed(
       property: dataSource,
       to: #selector(UICollectionViewDataSource.numberOfSections(in:)),
       map: { (dataSource: DataSource?, _: UICollectionView) -> Int in dataSource?.numberOfSections ?? 0 }

--- a/Sources/UIKit/UIControl.swift
+++ b/Sources/UIKit/UIControl.swift
@@ -22,29 +22,29 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import UIKit
+import ReactiveKit
 
-public extension UIControl {
+public extension ReactiveExtensions where Base: UIControl {
 
-  public func bnd_controlEvents(_ events: UIControlEvents) -> Signal1<Void> {
-    let _self = self
-    return Signal { [weak _self] observer in
-      guard let _self = _self else {
+  public func controlEvents(_ events: UIControlEvents) -> SafeSignal<Void> {
+    let base = self.base
+    return Signal { [weak base] observer in
+      guard let base = base else {
         observer.completed()
         return NonDisposable.instance
       }
-      let target = BNDControlTarget(control: _self, events: events) {
+      let target = BNDControlTarget(control: base, events: events) {
         observer.next()
       }
       return BlockDisposable {
         target.unregister()
       }
-    }.take(until: bnd_deallocated)
+    }.take(until: base.deallocated)
   }
 
-  public var bnd_isEnabled: Bond<UIControl, Bool> {
-    return Bond(target: self) { $0.isEnabled = $1 }
+  public var isEnabled: Bond<Bool> {
+    return bond { $0.isEnabled = $1 }
   }
 }
 

--- a/Sources/UIKit/UIDatePicker.swift
+++ b/Sources/UIKit/UIDatePicker.swift
@@ -29,9 +29,8 @@ import ReactiveKit
 
 public extension ReactiveExtensions where Base: UIDatePicker {
 
-  public var date: DynamicSubject<UIDatePicker, Date> {
-    return DynamicSubject(
-      target: base,
+  public var date: DynamicSubject<Date> {
+    return dynamicSubject(
       signal: controlEvents(.valueChanged).eraseType(),
       get: { $0.date },
       set: { $0.date = $1 }

--- a/Sources/UIKit/UIDatePicker.swift
+++ b/Sources/UIKit/UIDatePicker.swift
@@ -24,16 +24,15 @@
 
 import UIKit
 import ReactiveKit
-import Foundation
 
 #if os(iOS)
 
-public extension UIDatePicker {
+public extension ReactiveExtensions where Base: UIDatePicker {
 
-  public var bnd_date: DynamicSubject<UIDatePicker, Date> {
+  public var date: DynamicSubject<UIDatePicker, Date> {
     return DynamicSubject(
-      target: self,
-      signal: bnd_controlEvents(.valueChanged).eraseType(),
+      target: base,
+      signal: controlEvents(.valueChanged).eraseType(),
       get: { $0.date },
       set: { $0.date = $1 }
     )
@@ -43,7 +42,7 @@ public extension UIDatePicker {
 extension UIDatePicker: BindableProtocol {
 
   public func bind(signal: Signal<Date, NoError>) -> Disposable {
-    return bnd_date.bind(signal: signal)
+    return reactive.date.bind(signal: signal)
   }
 }
 

--- a/Sources/UIKit/UIGestureRecognizer.swift
+++ b/Sources/UIKit/UIGestureRecognizer.swift
@@ -25,9 +25,9 @@
 import UIKit
 import ReactiveKit
 
-public extension UIGestureRecognizer {
-  
-  public var bnd_enabled: Bond<UIGestureRecognizer, Bool> {
-    return Bond(target: self) { $0.isEnabled = $1 }
+public extension ReactiveExtensions where Base: UIGestureRecognizer {
+
+  public var isEnabled: Bond<Bool> {
+    return bond { $0.isEnabled = $1 }
   }
 }

--- a/Sources/UIKit/UIImageView.swift
+++ b/Sources/UIKit/UIImageView.swift
@@ -22,19 +22,19 @@
 //  THE SOFTWARE.
 //
 
-import ReactiveKit
 import UIKit
+import ReactiveKit
 
-extension UIImageView {
+public extension ReactiveExtensions where Base: UIImageView {
 
-  public var bnd_image: Bond<UIImageView, UIImage?> {
-    return Bond(target: self) { $0.image = $1 }
+  public var image: Bond<UIImage?> {
+    return bond { $0.image = $1 }
   }
 }
 
 extension UIImageView: BindableProtocol {
 
   public func bind(signal: Signal<UIImage?, NoError>) -> Disposable {
-    return bnd_image.bind(signal: signal)
+    return reactive.image.bind(signal: signal)
   }
 }

--- a/Sources/UIKit/UILabel.swift
+++ b/Sources/UIKit/UILabel.swift
@@ -25,24 +25,24 @@
 import UIKit
 import ReactiveKit
 
-public extension UILabel {
+public extension ReactiveExtensions where Base: UILabel {
 
-  public var bnd_text: Bond<UILabel, String?> {
-    return Bond(target: self) { $0.text = $1 }
+  public var text: Bond<String?> {
+    return bond { $0.text = $1 }
   }
 
-  public var bnd_attributedText: Bond<UILabel, NSAttributedString?> {
-    return Bond(target: self) { $0.attributedText = $1 }
+  public var attributedText: Bond<NSAttributedString?> {
+    return bond { $0.attributedText = $1 }
   }
 
-  public var bnd_textColor: Bond<UILabel, UIColor?> {
-    return Bond(target: self) { $0.textColor = $1 }
+  public var textColor: Bond<UIColor?> {
+    return bond { $0.textColor = $1 }
   }
 }
 
 extension UILabel: BindableProtocol {
 
   public func bind(signal: Signal<String?, NoError>) -> Disposable {
-    return bnd_text.bind(signal: signal)
+    return reactive.text.bind(signal: signal)
   }
 }

--- a/Sources/UIKit/UINavigationBar.swift
+++ b/Sources/UIKit/UINavigationBar.swift
@@ -23,10 +23,11 @@
 //
 
 import UIKit
+import ReactiveKit
 
-public extension UINavigationBar {
+public extension ReactiveExtensions where Base: UINavigationBar {
 
-  public var bnd_barTintColor: Bond<UINavigationBar, UIColor?> {
-    return Bond(target: self) { $0.barTintColor = $1 }
+  public var barTintColor: Bond<UIColor?> {
+    return bond { $0.barTintColor = $1 }
   }
 }

--- a/Sources/UIKit/UINavigationItem.swift
+++ b/Sources/UIKit/UINavigationItem.swift
@@ -23,10 +23,11 @@
 //
 
 import UIKit
+import ReactiveKit
 
-public extension UINavigationItem {
+public extension ReactiveExtensions where Base: UINavigationItem {
 
-  public var bnd_title: Bond<UINavigationItem, String?> {
-    return Bond(target: self) { $0.title = $1 }
+  public var title: Bond<String?> {
+    return bond { $0.title = $1 }
   }
 }

--- a/Sources/UIKit/UIProgressView.swift
+++ b/Sources/UIKit/UIProgressView.swift
@@ -25,16 +25,16 @@
 import ReactiveKit
 import UIKit
 
-public extension UIProgressView {
+public extension ReactiveExtensions where Base: UIProgressView {
 
-  public var bnd_progress: Bond<UIProgressView, Float> {
-    return Bond(target: self) { $0.progress = $1 }
+  public var progress: Bond<Float> {
+    return bond { $0.progress = $1 }
   }
 }
 
 extension UIProgressView: BindableProtocol {
 
   public func bind(signal: Signal<Float, NoError>) -> Disposable {
-    return bnd_progress.bind(signal: signal)
+    return reactive.progress.bind(signal: signal)
   }
 }

--- a/Sources/UIKit/UIRefreshControl.swift
+++ b/Sources/UIKit/UIRefreshControl.swift
@@ -27,12 +27,12 @@ import ReactiveKit
 
 #if os(iOS)
 
-extension UIRefreshControl {
+public extension ReactiveExtensions where Base: UIRefreshControl {
 
-  public var bnd_refreshing: DynamicSubject<UIRefreshControl, Bool> {
+  public var refreshing: DynamicSubject<UIRefreshControl, Bool> {
     return DynamicSubject(
-      target: self,
-      signal: bnd_controlEvents(.valueChanged).eraseType(),
+      target: base,
+      signal: controlEvents(.valueChanged).eraseType(),
       get: { $0.isRefreshing },
       set: { if $1 { $0.beginRefreshing() } else { $0.endRefreshing() } }
     )
@@ -42,7 +42,7 @@ extension UIRefreshControl {
 extension UIRefreshControl: BindableProtocol {
 
   public func bind(signal: Signal<Bool, NoError>) -> Disposable {
-    return bnd_refreshing.bind(signal: signal)
+    return reactive.refreshing.bind(signal: signal)
   }
 }
 

--- a/Sources/UIKit/UIRefreshControl.swift
+++ b/Sources/UIKit/UIRefreshControl.swift
@@ -29,9 +29,8 @@ import ReactiveKit
 
 public extension ReactiveExtensions where Base: UIRefreshControl {
 
-  public var refreshing: DynamicSubject<UIRefreshControl, Bool> {
-    return DynamicSubject(
-      target: base,
+  public var refreshing: DynamicSubject<Bool> {
+    return dynamicSubject(
       signal: controlEvents(.valueChanged).eraseType(),
       get: { $0.isRefreshing },
       set: { if $1 { $0.beginRefreshing() } else { $0.endRefreshing() } }

--- a/Sources/UIKit/UISegmentedControl.swift
+++ b/Sources/UIKit/UISegmentedControl.swift
@@ -25,12 +25,12 @@
 import UIKit
 import ReactiveKit
 
-extension UISegmentedControl {
+public extension ReactiveExtensions where Base: UISegmentedControl {
 
-  public var bnd_selectedSegmentIndex: DynamicSubject<UISegmentedControl, Int> {
+  public var selectedSegmentIndex: DynamicSubject<UISegmentedControl, Int> {
     return DynamicSubject(
-      target: self,
-      signal: bnd_controlEvents(.valueChanged).eraseType(),
+      target: base,
+      signal: controlEvents(.valueChanged).eraseType(),
       get: { $0.selectedSegmentIndex },
       set: { $0.selectedSegmentIndex = $1 }
     )
@@ -40,6 +40,6 @@ extension UISegmentedControl {
 extension UISegmentedControl: BindableProtocol {
 
   public func bind(signal: Signal<Int, NoError>) -> Disposable {
-    return bnd_selectedSegmentIndex.bind(signal: signal)
+    return reactive.selectedSegmentIndex.bind(signal: signal)
   }
 }

--- a/Sources/UIKit/UISegmentedControl.swift
+++ b/Sources/UIKit/UISegmentedControl.swift
@@ -27,9 +27,8 @@ import ReactiveKit
 
 public extension ReactiveExtensions where Base: UISegmentedControl {
 
-  public var selectedSegmentIndex: DynamicSubject<UISegmentedControl, Int> {
-    return DynamicSubject(
-      target: base,
+  public var selectedSegmentIndex: DynamicSubject<Int> {
+    return dynamicSubject(
       signal: controlEvents(.valueChanged).eraseType(),
       get: { $0.selectedSegmentIndex },
       set: { $0.selectedSegmentIndex = $1 }

--- a/Sources/UIKit/UISlider.swift
+++ b/Sources/UIKit/UISlider.swift
@@ -27,12 +27,12 @@ import ReactiveKit
 
 #if os(iOS)
 
-extension UISlider {
+public extension ReactiveExtensions where Base: UISlider {
 
-  public var bnd_value: DynamicSubject<UISlider, Float> {
+  public var value: DynamicSubject<UISlider, Float> {
     return DynamicSubject(
-      target: self,
-      signal: bnd_controlEvents(.valueChanged).eraseType(),
+      target: base,
+      signal: controlEvents(.valueChanged).eraseType(),
       get: { $0.value },
       set: { $0.value = $1 }
     )
@@ -42,7 +42,7 @@ extension UISlider {
 extension UISlider: BindableProtocol {
 
   public func bind(signal: Signal<Float, NoError>) -> Disposable {
-    return bnd_value.bind(signal: signal)
+    return reactive.value.bind(signal: signal)
   }
 }
 

--- a/Sources/UIKit/UISlider.swift
+++ b/Sources/UIKit/UISlider.swift
@@ -29,9 +29,8 @@ import ReactiveKit
 
 public extension ReactiveExtensions where Base: UISlider {
 
-  public var value: DynamicSubject<UISlider, Float> {
-    return DynamicSubject(
-      target: base,
+  public var value: DynamicSubject<Float> {
+    return dynamicSubject(
       signal: controlEvents(.valueChanged).eraseType(),
       get: { $0.value },
       set: { $0.value = $1 }

--- a/Sources/UIKit/UIStepper.swift
+++ b/Sources/UIKit/UIStepper.swift
@@ -29,9 +29,8 @@ import ReactiveKit
   
   public extension ReactiveExtensions where Base: UIStepper {
     
-    public var value: DynamicSubject<UIStepper, Double> {
-      return DynamicSubject(
-        target: base,
+    public var value: DynamicSubject<Double> {
+      return dynamicSubject(
         signal: controlEvents(.valueChanged).eraseType(),
         get: { $0.value },
         set: { $0.value = $1 }

--- a/Sources/UIKit/UIStepper.swift
+++ b/Sources/UIKit/UIStepper.swift
@@ -27,12 +27,12 @@ import ReactiveKit
 
 #if os(iOS)
   
-  extension UIStepper {
+  public extension ReactiveExtensions where Base: UIStepper {
     
-    public var bnd_value: DynamicSubject<UIStepper, Double> {
+    public var value: DynamicSubject<UIStepper, Double> {
       return DynamicSubject(
-        target: self,
-        signal: bnd_controlEvents(.valueChanged).eraseType(),
+        target: base,
+        signal: controlEvents(.valueChanged).eraseType(),
         get: { $0.value },
         set: { $0.value = $1 }
       )
@@ -42,7 +42,7 @@ import ReactiveKit
   extension UIStepper: BindableProtocol {
     
     public func bind(signal: Signal<Double, NoError>) -> Disposable {
-      return bnd_value.bind(signal: signal)
+      return reactive.value.bind(signal: signal)
     }
   }
   

--- a/Sources/UIKit/UISwitch.swift
+++ b/Sources/UIKit/UISwitch.swift
@@ -27,12 +27,12 @@ import ReactiveKit
 
 #if os(iOS)
 
-extension UISwitch {
+public extension ReactiveExtensions where Base: UISwitch {
   
-  public var bnd_isOn: DynamicSubject<UISwitch, Bool> {
+  public var isOn: DynamicSubject<UISwitch, Bool> {
     return DynamicSubject(
-      target: self,
-      signal: bnd_controlEvents(.valueChanged).eraseType(),
+      target: base,
+      signal: controlEvents(.valueChanged).eraseType(),
       get: { $0.isOn },
       set: { $0.isOn = $1 }
     )
@@ -42,7 +42,7 @@ extension UISwitch {
 extension UISwitch: BindableProtocol {
   
   public func bind(signal: Signal<Bool, NoError>) -> Disposable {
-    return bnd_isOn.bind(signal: signal)
+    return reactive.isOn.bind(signal: signal)
   }
 }
 

--- a/Sources/UIKit/UISwitch.swift
+++ b/Sources/UIKit/UISwitch.swift
@@ -29,9 +29,8 @@ import ReactiveKit
 
 public extension ReactiveExtensions where Base: UISwitch {
   
-  public var isOn: DynamicSubject<UISwitch, Bool> {
-    return DynamicSubject(
-      target: base,
+  public var isOn: DynamicSubject<Bool> {
+    return dynamicSubject(
       signal: controlEvents(.valueChanged).eraseType(),
       get: { $0.isOn },
       set: { $0.isOn = $1 }

--- a/Sources/UIKit/UITableView.swift
+++ b/Sources/UIKit/UITableView.swift
@@ -25,14 +25,14 @@
 import UIKit
 import ReactiveKit
 
-public extension UITableView {
+public extension ReactiveExtensions where Base: UITableView {
 
-  public var bnd_delegate: ProtocolProxy {
-    return protocolProxy(for: UITableViewDelegate.self, setter: NSSelectorFromString("setDelegate:"))
+  public var delegate: ProtocolProxy {
+    return base.protocolProxy(for: UITableViewDelegate.self, setter: NSSelectorFromString("setDelegate:"))
   }
 
-  public var bnd_dataSource: ProtocolProxy {
-    return protocolProxy(for: UITableViewDataSource.self, setter: NSSelectorFromString("setDataSource:"))
+  public var dataSource: ProtocolProxy {
+    return base.protocolProxy(for: UITableViewDataSource.self, setter: NSSelectorFromString("setDataSource:"))
   }
 }
 
@@ -123,21 +123,21 @@ public extension SignalProtocol where Element: DataSourceEventProtocol, Error ==
   public func bind<B: TableViewBond>(to tableView: UITableView, using bond: B) -> Disposable where B.DataSource == DataSource {
     let dataSource = Property<DataSource?>(nil)
 
-    tableView.bnd_dataSource.feed(
+    tableView.reactive.dataSource.feed(
       property: dataSource,
       to: #selector(UITableViewDataSource.tableView(_:cellForRowAt:)),
       map: { (dataSource: DataSource?, tableView: UITableView, indexPath: NSIndexPath) -> UITableViewCell in
         return bond.cellForRow(at: indexPath as IndexPath, tableView: tableView, dataSource: dataSource!)
     })
 
-    tableView.bnd_dataSource.feed(
+    tableView.reactive.dataSource.feed(
       property: dataSource,
       to: #selector(UITableViewDataSource.tableView(_:titleForHeaderInSection:)),
       map: { (dataSource: DataSource?, tableView: UITableView, index: Int) -> NSString? in
         return bond.titleForHeader(in: index, dataSource: dataSource!) as NSString?
     })
 
-    tableView.bnd_dataSource.feed(
+    tableView.reactive.dataSource.feed(
       property: dataSource,
       to: #selector(UITableViewDataSource.tableView(_:titleForFooterInSection:)),
       map: { (dataSource: DataSource?, tableView: UITableView, index: Int) -> NSString? in
@@ -145,14 +145,14 @@ public extension SignalProtocol where Element: DataSourceEventProtocol, Error ==
     })
 
 
-    tableView.bnd_dataSource.feed(
+    tableView.reactive.dataSource.feed(
       property: dataSource,
       to: #selector(UITableViewDataSource.tableView(_:numberOfRowsInSection:)),
       map: { (dataSource: DataSource?, _: UITableView, section: Int) -> Int in
         dataSource?.numberOfItems(inSection: section) ?? 0
     })
 
-    tableView.bnd_dataSource.feed(
+    tableView.reactive.dataSource.feed(
       property: dataSource,
       to: #selector(UITableViewDataSource.numberOfSections(in:)),
       map: { (dataSource: DataSource?, _: UITableView) -> Int in dataSource?.numberOfSections ?? 0 }

--- a/Sources/UIKit/UITextField.swift
+++ b/Sources/UIKit/UITextField.swift
@@ -25,34 +25,34 @@
 import UIKit
 import ReactiveKit
 
-public extension UITextField {
+public extension ReactiveExtensions where Base: UITextField {
 
-  public var bnd_text: DynamicSubject<UITextField, String?> {
+  public var text: DynamicSubject<UITextField, String?> {
     return DynamicSubject(
-      target: self,
-      signal: bnd_controlEvents(.allEditingEvents).eraseType(),
+      target: base,
+      signal: controlEvents(.allEditingEvents).eraseType(),
       get: { $0.text },
       set: { $0.text = $1 }
     )
   }
 
-  public var bnd_attributedText: DynamicSubject<UITextField, NSAttributedString?> {
+  public var attributedText: DynamicSubject<UITextField, NSAttributedString?> {
     return DynamicSubject(
-      target: self,
-      signal: bnd_controlEvents(.allEditingEvents).eraseType(),
+      target: base,
+      signal: controlEvents(.allEditingEvents).eraseType(),
       get: { $0.attributedText },
       set: { $0.attributedText = $1 }
     )
   }
 
-  public var bnd_textColor: Bond<UITextField, UIColor?> {
-    return Bond(target: self) { $0.textColor = $1 }
+  public var textColor: Bond<UIColor?> {
+    return bond { $0.textColor = $1 }
   }
 }
 
 extension UITextField: BindableProtocol {
 
   public func bind(signal: Signal<String?, NoError>) -> Disposable {
-    return bnd_text.bind(signal: signal)
+    return reactive.text.bind(signal: signal)
   }
 }

--- a/Sources/UIKit/UITextField.swift
+++ b/Sources/UIKit/UITextField.swift
@@ -27,18 +27,16 @@ import ReactiveKit
 
 public extension ReactiveExtensions where Base: UITextField {
 
-  public var text: DynamicSubject<UITextField, String?> {
-    return DynamicSubject(
-      target: base,
+  public var text: DynamicSubject<String?> {
+    return dynamicSubject(
       signal: controlEvents(.allEditingEvents).eraseType(),
       get: { $0.text },
       set: { $0.text = $1 }
     )
   }
 
-  public var attributedText: DynamicSubject<UITextField, NSAttributedString?> {
-    return DynamicSubject(
-      target: base,
+  public var attributedText: DynamicSubject<NSAttributedString?> {
+    return dynamicSubject(
       signal: controlEvents(.allEditingEvents).eraseType(),
       get: { $0.attributedText },
       set: { $0.attributedText = $1 }

--- a/Sources/UIKit/UITextView.swift
+++ b/Sources/UIKit/UITextView.swift
@@ -25,36 +25,36 @@
 import UIKit
 import ReactiveKit
 
-public extension UITextView {
+public extension ReactiveExtensions where Base: UITextView {
 
-  public var bnd_text: DynamicSubject<UITextView, String?> {
+  public var text: DynamicSubject<UITextView, String?> {
     let notificationName = NSNotification.Name.UITextViewTextDidChange
     return DynamicSubject(
-      target: self,
-      signal: NotificationCenter.default.bnd_notification(name: notificationName, object: self).eraseType(),
+      target: base,
+      signal: NotificationCenter.default.reactive.notification(name: notificationName, object: base).eraseType(),
       get: { $0.text },
       set: { $0.text = $1 }
     )
   }
 
-  public var bnd_attributedText: DynamicSubject<UITextView, NSAttributedString?> {
+  public var attributedText: DynamicSubject<UITextView, NSAttributedString?> {
     let notificationName = NSNotification.Name.UITextViewTextDidChange
     return DynamicSubject(
-      target: self,
-      signal: NotificationCenter.default.bnd_notification(name: notificationName, object: self).eraseType(),
+      target: base,
+      signal: NotificationCenter.default.reactive.notification(name: notificationName, object: base).eraseType(),
       get: { $0.attributedText },
       set: { $0.attributedText = $1 }
     )
   }
 
-  public var bnd_textColor: Bond<UITextView, UIColor?> {
-    return Bond(target: self) { $0.textColor = $1 }
+  public var textColor: Bond<UIColor?> {
+    return bond { $0.textColor = $1 }
   }
 }
 
 extension UITextView: BindableProtocol {
 
   public func bind(signal: Signal<String?, NoError>) -> Disposable {
-    return bnd_text.bind(signal: signal)
+    return reactive.text.bind(signal: signal)
   }
 }

--- a/Sources/UIKit/UITextView.swift
+++ b/Sources/UIKit/UITextView.swift
@@ -27,20 +27,18 @@ import ReactiveKit
 
 public extension ReactiveExtensions where Base: UITextView {
 
-  public var text: DynamicSubject<UITextView, String?> {
+  public var text: DynamicSubject<String?> {
     let notificationName = NSNotification.Name.UITextViewTextDidChange
-    return DynamicSubject(
-      target: base,
+    return dynamicSubject(
       signal: NotificationCenter.default.reactive.notification(name: notificationName, object: base).eraseType(),
       get: { $0.text },
       set: { $0.text = $1 }
     )
   }
 
-  public var attributedText: DynamicSubject<UITextView, NSAttributedString?> {
+  public var attributedText: DynamicSubject<NSAttributedString?> {
     let notificationName = NSNotification.Name.UITextViewTextDidChange
-    return DynamicSubject(
-      target: base,
+    return dynamicSubject(
       signal: NotificationCenter.default.reactive.notification(name: notificationName, object: base).eraseType(),
       get: { $0.attributedText },
       set: { $0.attributedText = $1 }

--- a/Sources/UIKit/UIView.swift
+++ b/Sources/UIKit/UIView.swift
@@ -23,26 +23,27 @@
 //
 
 import UIKit
+import ReactiveKit
 
-extension UIView {
+extension ReactiveExtensions where Base: UIView {
 
-  public var bnd_alpha: Bond<UIView, CGFloat> {
-    return Bond(target: self) { $0.alpha = $1 }
+  public var alpha: Bond<CGFloat> {
+    return bond { $0.alpha = $1 }
   }
 
-  public var bnd_backgroundColor: Bond<UIView, UIColor?> {
-    return Bond(target: self) { $0.backgroundColor = $1 }
+  public var backgroundColor: Bond<UIColor?> {
+    return bond { $0.backgroundColor = $1 }
   }
 
-  public var bnd_isHidden: Bond<UIView, Bool> {
-    return Bond(target: self) { $0.isHidden = $1 }
+  public var isHidden: Bond<Bool> {
+    return bond { $0.isHidden = $1 }
   }
 
-  public var bnd_isUserInteractionEnabled: Bond<UIView, Bool> {
-    return Bond(target: self) { $0.isUserInteractionEnabled = $1 }
+  public var isUserInteractionEnabled: Bond<Bool> {
+    return bond { $0.isUserInteractionEnabled = $1 }
   }
 
-  public var bnd_tintColor: Bond<UIView, UIColor?> {
-    return Bond(target: self) { $0.tintColor = $1 }
+  public var tintColor: Bond<UIColor?> {
+    return bond { $0.tintColor = $1 }
   }
 }


### PR DESCRIPTION
Support fully nested 2D replace of `MutableObservable2DArray` using `Diff.swift` library's `.nestedExtendedDiff` API that works on 2D arrays to enable multi-sections arrays observing of series of events (deleteSection, deleteItems, insertSections, insertItems, moveSection, moveItem) that migrate the old 2DArray to the new 2DArray