### PR TITLE
Replace2D

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		16D30F071D65D7F800C2435D /* NSColorWell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F061D65D7F800C2435D /* NSColorWell.swift */; };
 		16D30F091D65D82D00C2435D /* NSAppearanceCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F081D65D82C00C2435D /* NSAppearanceCustomization.swift */; };
 		16D30F0B1D65E8C700C2435D /* NSTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F0A1D65E8C700C2435D /* NSTableView.swift */; };
+		1F5F73AD1E267BC10001E3CC /* Observable2DArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5F73AC1E267BC10001E3CC /* Observable2DArrayTests.swift */; };
 		227DEF051DCB87BF00213852 /* UIGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227DEF041DCB87BF00213852 /* UIGestureRecognizer.swift */; };
 		90A3FACD1E0C8D9A0086A7F1 /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
 		90A3FACE1E0C8D9F0086A7F1 /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
@@ -275,6 +276,7 @@
 		16D30F061D65D7F800C2435D /* NSColorWell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSColorWell.swift; sourceTree = "<group>"; };
 		16D30F081D65D82C00C2435D /* NSAppearanceCustomization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAppearanceCustomization.swift; sourceTree = "<group>"; };
 		16D30F0A1D65E8C700C2435D /* NSTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTableView.swift; sourceTree = "<group>"; };
+		1F5F73AC1E267BC10001E3CC /* Observable2DArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable2DArrayTests.swift; sourceTree = "<group>"; };
 		227DEF041DCB87BF00213852 /* UIGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIGestureRecognizer.swift; sourceTree = "<group>"; };
 		90A3FAC21E0C8D8B0086A7F1 /* Diff.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Diff.xcodeproj; path = Carthage/Checkouts/Diff.swift/Diff.xcodeproj; sourceTree = "<group>"; };
 		EC06A8751DBCB147006AEA81 /* NSObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObjectTests.swift; sourceTree = "<group>"; };
@@ -431,6 +433,7 @@
 				ECCF8A571D9007AF00575DA8 /* BondTests.swift */,
 				ECD594091D93EC9700C840C2 /* DynamicSubjectTests.swift */,
 				ECCF8A511D8FFEF300575DA8 /* ObservableArrayTests.swift */,
+				1F5F73AC1E267BC10001E3CC /* Observable2DArrayTests.swift */,
 				16887E2F1D74499A00EDA099 /* ProtocolProxyTests.swift */,
 				16210A4A1D3EC474004AEDF3 /* UIKitTests.swift */,
 				EC96935A1D943B15004EB5EE /* UITableViewTests.swift */,
@@ -905,6 +908,7 @@
 				16887E301D74499A00EDA099 /* ProtocolProxyTests.swift in Sources */,
 				ECD5940A1D93EC9700C840C2 /* DynamicSubjectTests.swift in Sources */,
 				EC06A8761DBCB147006AEA81 /* NSObjectTests.swift in Sources */,
+				1F5F73AD1E267BC10001E3CC /* Observable2DArrayTests.swift in Sources */,
 				ECCF8A581D9007AF00575DA8 /* BondTests.swift in Sources */,
 				EC96935B1D943B15004EB5EE /* UITableViewTests.swift in Sources */,
 				16887E321D744A1400EDA099 /* Helpers.swift in Sources */,

--- a/BondTests/Observable2DArrayTests.swift
+++ b/BondTests/Observable2DArrayTests.swift
@@ -1,0 +1,48 @@
+//
+//  Observable2DArrayTests.swift
+//  Bond
+//
+//  Created by MOHAMMAD TAWEEL on 1/11/17.
+//  Copyright © 2017 Swift Bond. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+@testable import Bond
+
+class Observable2DArrayTests: XCTestCase {
+  
+  var array2D: MutableObservable2DArray<String,Int>!
+  
+  override func setUp() {
+    super.setUp()
+    array2D = MutableObservable2DArray([
+      Observable2DArraySection(metadata: "units", items: [1,2,3]),
+      Observable2DArraySection(metadata: "tens", items: [10,20,30]),
+      Observable2DArraySection(metadata: "hundreds", items: [100,200,300]),
+      Observable2DArraySection(metadata: "thousands", items: [1000,2000,3000]),
+    ])
+  }
+  
+  func testReplace2D() {
+    
+    let newArray = MutableObservable2DArray([
+      Observable2DArraySection(metadata: "tens", items: [10,30]),
+      Observable2DArraySection(metadata: "hundreds", items: [100,200,400]),
+      Observable2DArraySection(metadata: "hundredssss", items: [100,200,400]),
+      Observable2DArraySection(metadata: "units", items: [4,3,2]),
+      ])
+    
+    array2D.replace2D(with: newArray, performDiff: true)
+    print(array2D)
+//    array.expectNext([
+//      ObservableArrayEvent(change: .reset, source: array),
+//      ObservableArrayEvent(change: .inserts([3]), source: array)
+//      ])
+//    
+//    array.append(4)
+//    XCTAssert(array == ObservableArray([1, 2, 3, 4]))
+}
+
+}

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "wokalski/Diff.swift" "0.4.2"
-github "ReactiveKit/ReactiveKit" "854494efeb4276d942c63d85901997ad6400865e"
+github "ReactiveKit/ReactiveKit" "v3.2.1"

--- a/Sources/Collections/Observable2DArray.swift
+++ b/Sources/Collections/Observable2DArray.swift
@@ -447,9 +447,11 @@ extension MutableObservable2DArray where Item: Equatable {
 
 extension MutableObservable2DArray where Item: Equatable, SectionMetadata: Equatable {
   
-  // Replace the entire 2DArray performing diff [if given] on all sections and section's items
-  // resulting in a series of ordered events (deleteSection, deleteItems, insertSections, insertItems) that migrate the old 2DArray to the new 2DArray
-  // Note that both Item and SectionMetadata should be Equatable
+  /// Replace the entire 2DArray performing nested diff (if preformDiff is true) on all
+  /// sections and section's items resulting in a series of ordered events (deleteSection,
+  /// deleteItems, insertSections, insertItems, moveSection, moveItem) that migrate the old
+  /// 2DArray to the new 2DArray
+  /// Note that both Item and SectionMetadata should be Equatable
   public func replace2D(with list: Observable2DArray<SectionMetadata, Item>, performDiff: Bool) {
     
     if performDiff {

--- a/Sources/Collections/Observable2DArray.swift
+++ b/Sources/Collections/Observable2DArray.swift
@@ -448,7 +448,7 @@ extension MutableObservable2DArray where Item: Equatable {
 extension MutableObservable2DArray where Item: Equatable, SectionMetadata: Equatable {
   
   /// Replace the entire 2DArray performing nested diff (if preformDiff is true) on all
-  /// sections and section's items resulting in a series of ordered events (deleteSection,
+  /// sections and section's items resulting in a series of events (deleteSection,
   /// deleteItems, insertSections, insertItems, moveSection, moveItem) that migrate the old
   /// 2DArray to the new 2DArray
   /// Note that both Item and SectionMetadata should be Equatable

--- a/Sources/Collections/Observable2DArray.swift
+++ b/Sources/Collections/Observable2DArray.swift
@@ -27,17 +27,17 @@ import Diff
 
 public enum Observable2DArrayChange {
   case reset
-
+  
   case insertItems([IndexPath])
   case deleteItems([IndexPath])
   case updateItems([IndexPath])
   case moveItem(IndexPath, IndexPath)
-
+  
   case insertSections(IndexSet)
   case deleteSections(IndexSet)
   case updateSections(IndexSet)
   case moveSection(Int, Int)
-
+  
   case beginBatchEditing
   case endBatchEditing
 }
@@ -56,39 +56,67 @@ public struct Observable2DArrayEvent<SectionMetadata, Item> {
 
 /// Represents a section in 2D array.
 /// Section contains its metadata (e.g. header string) and items.
-public struct Observable2DArraySection<Metadata, Item> {
-
+public struct Observable2DArraySection<Metadata, Item>: Collection {
+  
   public var metadata: Metadata
   public var items: [Item]
-
+  
   public init(metadata: Metadata, items: [Item] = []) {
     self.metadata = metadata
     self.items = items
   }
+  
+  
+  public var startIndex: Int {
+    return items.startIndex
+  }
+  
+  
+  public var endIndex: Int {
+    return items.endIndex
+  }
+  
+  public var count: Int {
+    return items.count
+  }
+  
+  public var isEmpty: Bool {
+    return items.isEmpty
+  }
+  
+  public func index(after i: Int) -> Int {
+    return items.index(after: i)
+  }
+  public subscript(index: Int) -> Item {
+    get {
+      return items[index]
+    }
+  }
+  
 }
 
 public class Observable2DArray<SectionMetadata, Item>: Collection, SignalProtocol {
-
+  
   public fileprivate(set) var sections: [Observable2DArraySection<SectionMetadata, Item>]
   fileprivate let subject = PublishSubject<Observable2DArrayEvent<SectionMetadata, Item>, NoError>()
   fileprivate let lock = NSRecursiveLock(name: "com.reactivekit.bond.observable2darray")
-
+  
   public init(_ sections:  [Observable2DArraySection<SectionMetadata, Item>] = []) {
     self.sections = sections
   }
-
+  
   public var numberOfSections: Int {
     return sections.count
   }
-
+  
   public func numberOfItems(inSection section: Int) -> Int {
     return sections[section].items.count
   }
-
+  
   public var startIndex: IndexPath {
     return IndexPath(item: 0, section: 0)
   }
-
+  
   public var endIndex: IndexPath {
     if numberOfSections == 0 {
       return IndexPath(item: 0, section: 0)
@@ -97,7 +125,7 @@ public class Observable2DArray<SectionMetadata, Item>: Collection, SignalProtoco
       return IndexPath(item: lastSection.items.count, section: numberOfSections - 1)
     }
   }
-
+  
   public func index(after i: IndexPath) -> IndexPath {
     if i.section < sections.count {
       let section = sections[i.section]
@@ -114,27 +142,27 @@ public class Observable2DArray<SectionMetadata, Item>: Collection, SignalProtoco
       return endIndex
     }
   }
-
+  
   public var isEmpty: Bool {
     return sections.reduce(true) { $0 && $1.items.isEmpty }
   }
-
+  
   public var count: Int {
     return sections.reduce(0) { $0 + $1.items.count }
   }
-
+  
   public subscript(index: IndexPath) -> Item {
     get {
       return sections[index.section].items[index.item]
     }
   }
-
+  
   public subscript(index: Int) -> Observable2DArraySection<SectionMetadata, Item> {
     get {
       return sections[index]
     }
   }
-
+  
   public func observe(with observer: @escaping (Event<Observable2DArrayEvent<SectionMetadata, Item>, NoError>) -> Void) -> Disposable {
     observer(.next(Observable2DArrayEvent(change: .reset, source: self)))
     return subject.observe(with: observer)
@@ -142,14 +170,14 @@ public class Observable2DArray<SectionMetadata, Item>: Collection, SignalProtoco
 }
 
 extension Observable2DArray: Deallocatable {
-
+  
   public var deallocated: Signal<Void, NoError> {
     return subject.disposeBag.deallocated
   }
 }
 
 public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<SectionMetadata, Item> {
-
+  
   /// Append new section at the end of the 2D array.
   public func appendSection(_ section: Observable2DArraySection<SectionMetadata, Item>) {
     lock.lock(); defer { lock.unlock() }
@@ -166,7 +194,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
       subject.next(Observable2DArrayEvent(change: .insertSections([sectionIndex]), source: self))
     }
   }
-
+  
   /// Append `item` to the section `section` of the array.
   public func appendItem(_ item: Item, toSection section: Int) {
     lock.lock(); defer { lock.unlock() }
@@ -174,7 +202,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     let indexPath = IndexPath(item: sections[section].items.count - 1, section: section)
     subject.next(Observable2DArrayEvent(change: .insertItems([indexPath]), source: self))
   }
-
+  
   /// Insert section at `index` with `items`.
   public func insert(section: Observable2DArraySection<SectionMetadata, Item>, at index: Int)  {
     lock.lock(); defer { lock.unlock() }
@@ -190,14 +218,14 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
       subject.next(Observable2DArrayEvent(change: .insertSections([index]), source: self))
     }
   }
-
+  
   /// Insert `item` at `indexPath`.
   public func insert(item: Item, at indexPath: IndexPath)  {
     lock.lock(); defer { lock.unlock() }
     sections[indexPath.section].items.insert(item, at: indexPath.item)
     subject.next(Observable2DArrayEvent(change: .insertItems([indexPath]), source: self))
   }
-
+  
   /// Insert `items` at index path `indexPath`.
   public func insert(contentsOf items: [Item], at indexPath: IndexPath) {
     lock.lock(); defer { lock.unlock() }
@@ -206,7 +234,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     let indexPaths = indices.map { IndexPath(item: $0, section: indexPath.section) }
     subject.next(Observable2DArrayEvent(change: .insertItems(indexPaths), source: self))
   }
-
+  
   /// Move the section at index `fromIndex` to index `toIndex`.
   public func moveSection(from fromIndex: Int, to toIndex: Int) {
     lock.lock(); defer { lock.unlock() }
@@ -214,7 +242,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     sections.insert(section, at: toIndex)
     subject.next(Observable2DArrayEvent(change: .moveSection(fromIndex, toIndex), source: self))
   }
-
+  
   /// Move the item at `fromIndexPath` to `toIndexPath`.
   public func moveItem(from fromIndexPath: IndexPath, to toIndexPath: IndexPath) {
     lock.lock(); defer { lock.unlock() }
@@ -222,7 +250,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     sections[toIndexPath.section].items.insert(item, at: toIndexPath.item)
     subject.next(Observable2DArrayEvent(change: .moveItem(fromIndexPath, toIndexPath), source: self))
   }
-
+  
   /// Remove and return the section at `index`.
   @discardableResult
   public func removeSection(at index: Int) -> Observable2DArraySection<SectionMetadata, Item> {
@@ -231,7 +259,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     subject.next(Observable2DArrayEvent(change: .deleteSections([index]), source: self))
     return element
   }
-
+  
   /// Remove and return the item at `indexPath`.
   @discardableResult
   public func removeItem(at indexPath: IndexPath) -> Item {
@@ -240,21 +268,21 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     subject.next(Observable2DArrayEvent(change: .deleteItems([indexPath]), source: self))
     return element
   }
-
+  
   /// Remove all items from the array. Keep empty sections.
   public func removeAllItems() {
     lock.lock(); defer { lock.unlock() }
     let indexPaths = sections.enumerated().reduce([]) { (indexPaths, section) -> [IndexPath] in
       indexPaths + section.element.items.indices.map { IndexPath(item: $0, section: section.offset) }
     }
-
+    
     for index in sections.indices {
       sections[index].items.removeAll()
     }
-
+    
     subject.next(Observable2DArrayEvent(change: .deleteItems(indexPaths), source: self))
   }
-
+  
   /// Remove all items and sections from the array.
   public func removeAllItemsAndSections() {
     lock.lock(); defer { lock.unlock() }
@@ -262,7 +290,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     sections.removeAll()
     subject.next(Observable2DArrayEvent(change: .deleteSections(IndexSet(integersIn: indices)), source: self))
   }
-
+  
   public override subscript(index: IndexPath) -> Item {
     get {
       return sections[index.section].items[index.item]
@@ -273,7 +301,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
       subject.next(Observable2DArrayEvent(change: .updateItems([index]), source: self))
     }
   }
-
+  
   /// Perform batched updates on the array.
   public func batchUpdate(_ update: (MutableObservable2DArray<SectionMetadata, Item>) -> Void) {
     lock.lock(); defer { lock.unlock() }
@@ -281,7 +309,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     update(self)
     subject.next(Observable2DArrayEvent(change: .endBatchEditing, source: self))
   }
-
+  
   /// Change the underlying value withouth notifying the observers.
   public func silentUpdate(_ update: (inout [Observable2DArraySection<SectionMetadata, Item>]) -> Void) {
     lock.lock(); defer { lock.unlock() }
@@ -290,7 +318,7 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
 }
 
 extension MutableObservable2DArray: BindableProtocol {
-
+  
   public func bind(signal: Signal<Observable2DArrayEvent<SectionMetadata, Item>, NoError>) -> Disposable {
     return signal
       .take(until: deallocated)
@@ -305,7 +333,7 @@ extension MutableObservable2DArray: BindableProtocol {
 // MARK: DataSourceProtocol conformation
 
 extension Observable2DArrayEvent: DataSourceEventProtocol {
-
+  
   public var kind: DataSourceEventKind {
     switch change {
     case .reset:
@@ -332,7 +360,7 @@ extension Observable2DArrayEvent: DataSourceEventProtocol {
       return .endUpdates
     }
   }
-
+  
   public var dataSource: Observable2DArray<SectionMetadata, Item> {
     return source
   }
@@ -340,6 +368,7 @@ extension Observable2DArrayEvent: DataSourceEventProtocol {
 
 extension Observable2DArray: DataSourceProtocol {
 }
+
 
 extension MutableObservable2DArray {
   
@@ -368,30 +397,30 @@ extension MutableObservable2DArray where Item: Equatable {
       lock.lock()
       let diff = sections[index].items.extendedDiff(section.items)
       let patch = diff.patch(from: sections[index].items, to: section.items)
-
+      
       subject.next(Observable2DArrayEvent(change: .beginBatchEditing, source: self))
       sections[index].metadata = section.metadata
       sections[index].items = section.items
-
+      
       for step in patch {
         switch step {
         case .insertion(let patchIndex, _):
           let indexPath = IndexPath(item: patchIndex, section: index)
           subject.next(Observable2DArrayEvent(change: .insertItems([indexPath]), source: self))
-
+          
         case .deletion(let patchIndex):
           let indexPath = IndexPath(item: patchIndex, section: index)
           subject.next(Observable2DArrayEvent(change: .deleteItems([indexPath]), source: self))
-
+          
         case .move(let from, let to):
           let fromIndexPath = IndexPath(item: from, section: index)
           let toIndexPath = IndexPath(item: to, section: index)
-
+          
           subject.next(Observable2DArrayEvent(change: .moveItem(fromIndexPath, toIndexPath), source: self))
           
         }
       }
-
+      
       subject.next(Observable2DArrayEvent(change: .endBatchEditing, source: self))
       lock.unlock()
     } else {
@@ -414,108 +443,88 @@ extension MutableObservable2DArray where Item: Equatable, SectionMetadata: Equat
   public func replace2D(with list: Observable2DArray<SectionMetadata, Item>, performDiff: Bool) {
     
     if performDiff {
+      
       lock.lock()
       
-      // gather old section's metada and new section's metadata
-      let oldSectionsMeta = sections.map({$0.metadata})
-      let newSectionsMeta = list.sections.map({$0.metadata})
+      // perform nested diff
+      let diff = sections.nestedExtendedDiff(to: list.sections, isEqualSection: {(oldSection, newSection) in
+        return oldSection.metadata == newSection.metadata
+      })
       
-      // perform diff on metadata to figure out inserted sections and deleted sections
-      let metaDiff = oldSectionsMeta.extendedDiff(newSectionsMeta)
-      let metaPatch = metaDiff.patch(from: newSectionsMeta, to: newSectionsMeta)
-      
-      //let metaDiff = Array.diff(oldSectionsMeta, newSectionsMeta)
-      
-      var sectionDeletes: [Int] = []
-      var sectionInserts: [Int] = []
-      var sectionMoves: [(from: Int, to: Int)] = []
-      sectionDeletes.reserveCapacity(metaPatch.count)
-      sectionInserts.reserveCapacity(metaPatch.count)
-      sectionMoves.reserveCapacity(metaPatch.count)
-      
-      for diffStep in metaPatch {
-        switch diffStep {
-        case .insertion(let index, _):
-          sectionInserts.append(index)
-        case .deletion(let index):
-          sectionDeletes.append(index)
-        case .move(let from, let to):
-          sectionMoves.append((from,to))
-          //subject.next(ObservableArrayEvent(change: .move(from, to), source: self))
-        }
-      }
-      
-      // get sections that stayed there a.k.a neither deleted nor inserted
-      var sectionsSame: [(new: Int, old: Int)] = []
-      for (i, entry) in newSectionsMeta.enumerated() {
-        if let oldIndex = oldSectionsMeta.index(of: entry) {
-          sectionsSame.append((new: i, old: oldIndex))
-          
-        }
-      }
-      
-      var deletesIndexPaths: [IndexPath] = []
-      var insertsIndexPaths: [IndexPath] = []
-      var movesIndexPaths: [(from: IndexPath, to: IndexPath)] = []
-      
-      // perform diff on sectionsSame items to get indecies that where deleted, inserted and moved inside those sections
-      for entry in sectionsSame {
-        
-        // the diff should happen between old section's items and new section's items on their corresponding indecies
-        let diff = sections[entry.old].items.extendedDiff(list[entry.new].items)
-        let patch = diff.patch(from: sections[entry.old].items, to: list[entry.new].items)
-
-        //let diff = Array.diff(sections[entry.old].items, list[entry.new].items)
-        
-        var deletes: [Int] = []
-        var inserts: [Int] = []
-        deletes.reserveCapacity(diff.count)
-        inserts.reserveCapacity(diff.count)
-
-        
-        for diffStep in patch {
-          switch diffStep {
-          case .insertion(let index, _):
-            inserts.append(index)
-          case .deletion(let index):
-            deletes.append(index)
-          case .move(let from, let to):
-            movesIndexPaths.append((IndexPath(item: from, section: entry.new), IndexPath(item: to, section: entry.new)))
-          }
-        }
-        
-        // deletes should always happen from the old section's place
-        deletesIndexPaths.append(contentsOf: deletes.map { IndexPath(item: $0, section: entry.old) })
-        
-        // insertions should alwyas happen to the new section's place
-        insertsIndexPaths.append(contentsOf: inserts.map { IndexPath(item: $0, section: entry.new) })
-        
-      }
-      
+      let update = NestedBatchUpdate(diff: diff)
       
       subject.next(Observable2DArrayEvent(change: .beginBatchEditing, source: self))
       sections = list.sections
-      subject.next(Observable2DArrayEvent(change: .deleteSections(IndexSet(sectionDeletes)), source: self))
-      subject.next(Observable2DArrayEvent(change: .deleteItems(deletesIndexPaths), source: self))
       
-      for entry in sectionMoves {
-        subject.next(Observable2DArrayEvent(change: .moveSection(entry.from, entry.to), source: self))
+      // item deletion
+      subject.next(Observable2DArrayEvent(change: .deleteItems(update.itemDeletions), source: self))
+      
+      // item insertions
+      subject.next(Observable2DArrayEvent(change: .insertItems(update.itemInsertions), source: self))
+      
+      // item moves
+      update.itemMoves.forEach {
+        subject.next(Observable2DArrayEvent(change: .moveItem($0.from, $0.to) , source: self))
       }
       
-      for entry in movesIndexPaths {
-        subject.next(Observable2DArrayEvent(change: .moveItem(entry.from, entry.to), source: self))
+      // section deletion
+      subject.next(Observable2DArrayEvent(change: .deleteSections(update.sectionDeletions), source: self))
+      
+      // section insertions
+      subject.next(Observable2DArrayEvent(change: .insertSections(update.sectionInsertions), source: self))
+      
+      // section moves
+      update.sectionMoves.forEach {
+        subject.next(Observable2DArrayEvent(change: .moveSection($0.from, $0.to), source: self))
       }
       
-      
-      subject.next(Observable2DArrayEvent(change: .insertSections(IndexSet(sectionInserts)), source: self))
-      subject.next(Observable2DArrayEvent(change: .insertItems(insertsIndexPaths), source: self))
       subject.next(Observable2DArrayEvent(change: .endBatchEditing, source: self))
       lock.unlock()
     } else {
       replace2D(with: list)
     }
   }
-  
 }
 
-
+struct NestedBatchUpdate {
+  let itemDeletions: [IndexPath]
+  let itemInsertions: [IndexPath]
+  let itemMoves: [(from: IndexPath, to: IndexPath)]
+  let sectionDeletions: IndexSet
+  let sectionInsertions: IndexSet
+  let sectionMoves: [(from: Int, to: Int)]
+  
+  init(diff: NestedExtendedDiff) {
+    
+    var itemDeletions: [IndexPath] = []
+    var itemInsertions: [IndexPath] = []
+    var itemMoves: [(IndexPath, IndexPath)] = []
+    var sectionDeletions: IndexSet = []
+    var sectionInsertions: IndexSet = []
+    var sectionMoves: [(from: Int, to: Int)] = []
+    
+    diff.forEach { element in
+      switch element {
+      case let .deleteElement(at, section):
+        itemDeletions.append(IndexPath(item: at, section: section))
+      case let .insertElement(at, section):
+        itemInsertions.append(IndexPath(item: at, section: section))
+      case let .moveElement(from, to):
+        itemMoves.append((IndexPath(item: from.item, section: from.section), IndexPath(item: to.item, section: to.section)))
+      case let .deleteSection(at):
+        sectionDeletions.insert(at)
+      case let .insertSection(at):
+        sectionInsertions.insert(at)
+      case let .moveSection(move):
+        sectionMoves.append(move)
+      }
+    }
+    
+    self.itemInsertions = itemInsertions
+    self.itemDeletions = itemDeletions
+    self.itemMoves = itemMoves
+    self.sectionMoves = sectionMoves
+    self.sectionInsertions = sectionInsertions
+    self.sectionDeletions = sectionDeletions
+  }
+}


### PR DESCRIPTION
Support fully nested 2D replace of `MutableObservable2DArray` using `Diff.swift` library's `.nestedExtendedDiff` API that works on 2D arrays to enable multi-sections arrays observing of series of events (`deleteSection`, `deleteItems`, `insertSections`, `insertItems`, `moveSection`, `moveItem`) that migrate the old `MutableObservable2DArray` to the new `MutableObservable2DArray`